### PR TITLE
Bugfix - in npm projects, XrayScanCache.json files are created in workspace

### DIFF
--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 
 /**
  * Cache for Xray scan.
@@ -22,14 +23,14 @@ public class ScanCache {
     /**
      * Construct an Xray scan cache.
      *
-     * @param projectName - The IDE project name.
+     * @param projectName - The IDE project name. In npm it is a full path to the directory containing the package.json.
      * @param basePath    - The directory for the cache.
      * @param logger      - The logger.
      * @throws IOException in case of I/O problem in the paths.
      */
     public ScanCache(String projectName, Path basePath, Log logger) throws IOException {
         scanCacheMap = new ScanCacheMap();
-        file = basePath.resolve(projectName + "_XrayScanCache.json").toFile();
+        file = basePath.resolve(Base64.getEncoder().encodeToString(projectName.getBytes()) + "XrayScanCache.json").toFile();
         if (!file.exists()) {
             Files.createDirectories(basePath);
             return;

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -6,6 +6,7 @@ import org.jfrog.build.extractor.scan.Artifact;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -30,7 +31,7 @@ public class ScanCache {
      */
     public ScanCache(String projectName, Path basePath, Log logger) throws IOException {
         scanCacheMap = new ScanCacheMap();
-        file = basePath.resolve(Base64.getEncoder().encodeToString(projectName.getBytes()) + "XrayScanCache.json").toFile();
+        file = basePath.resolve(Base64.getEncoder().encodeToString(projectName.getBytes(StandardCharsets.UTF_8)) + "XrayScanCache.json").toFile();
         if (!file.exists()) {
             Files.createDirectories(basePath);
             return;

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -24,7 +24,7 @@ public class ScanCache {
     /**
      * Construct an Xray scan cache.
      *
-     * @param projectName - The IDE project name. In npm it is a full path to the directory containing the package.json.
+     * @param projectName - The IDE project name. If this is an npm project, it is a full path to the directory containing the package.json.
      * @param basePath    - The directory for the cache.
      * @param logger      - The logger.
      * @throws IOException in case of I/O problem in the paths.


### PR DESCRIPTION
**The issue:**
In npm projects, the project name is the project full path.
When the scan cache tries to resolve the path to the project path, it fails and returns the path to the package.json directory. This instead of returning a path to `USER_HOME/.jfrog-idea-plugin/cache/projectName_XrayScanCache.json`. The results are: XrayScanCache.json files in the workspace.

**Solution:** 
Base64 encoding of project name.