### PR TITLE
Add loop detection mechanism in Go

### DIFF
--- a/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
@@ -88,7 +88,10 @@ public class GoTreeBuilder {
         }
     }
 
-    static void populateDependencyTree(DependencyTree currNode, String currNameVersionString, Map<String, List<String>> allDependencies) {
+    void populateDependencyTree(DependencyTree currNode, String currNameVersionString, Map<String, List<String>> allDependencies) {
+        if (hasLoop(currNode)) {
+            return;
+        }
         List<String> currDependencies = allDependencies.get(currNameVersionString);
         if (currDependencies == null) {
             return;
@@ -96,8 +99,24 @@ public class GoTreeBuilder {
         for (String dependency : currDependencies) {
             String[] dependencyNameVersion = dependency.split("@v");
             DependencyTree DependencyTree = new DependencyTree(dependencyNameVersion[0] + ":" + dependencyNameVersion[1]);
-            populateDependencyTree(DependencyTree, dependency, allDependencies);
             currNode.add(DependencyTree);
+            populateDependencyTree(DependencyTree, dependency, allDependencies);
         }
+    }
+
+    /**
+     * Return true if the node contains a loop.
+     *
+     * @param node - The dependency tree node
+     * @return true if the node contains a loop
+     */
+    private boolean hasLoop(DependencyTree node) {
+        for (DependencyTree parent = (DependencyTree) node.getParent(); parent != null; parent = (DependencyTree) parent.getParent()) {
+            if (Objects.equals(node.getUserObject(), parent.getUserObject())) {
+                logger.debug("Loop detected in " + node.getUserObject());
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
@@ -131,7 +131,8 @@ public class GoTreeBuilderTest {
         };
         Map<String, List<String>> allDependencies = getAllDependenciesForTest();
         DependencyTree rootNode = new DependencyTree();
-        GoTreeBuilder.populateDependencyTree(rootNode, "my/pkg/name1", allDependencies);
+        GoTreeBuilder treeBuilder = new GoTreeBuilder(Paths.get(""), null, log);
+        treeBuilder.populateDependencyTree(rootNode, "my/pkg/name1", allDependencies);
         validateDependencyTreeResults(expected, rootNode, false);
     }
 


### PR DESCRIPTION
Resolve stack overflow in Go projects that have loops in the dependency tree.
To reproduce:
Scan the following project: https://github.com/gogatekeeper/gatekeeper

The results:
> java.lang.StackOverflowError
        at java.base/java.lang.IllegalArgumentException.<init>(IllegalArgumentException.java:42)
        at java.base/java.util.regex.PatternSyntaxException.<init>(PatternSyntaxException.java:59)
        at java.base/java.util.regex.Pattern.error(Pattern.java:2027)
        at java.base/java.util.regex.Pattern.<init>(Pattern.java:1430)
        at java.base/java.util.regex.Pattern.compile(Pattern.java:1068)
        at java.base/java.lang.String.split(String.java:2317)
        at java.base/java.lang.String.split(String.java:2364)
        at com.jfrog.ide.common.go.GoTreeBuilder.populateDependenciesTree(GoTreeBuilder.java:97)
        at com.jfrog.ide.common.go.GoTreeBuilder.populateDependenciesTree(GoTreeBuilder.java:99)
        at com.jfrog.ide.common.go.GoTreeBuilder.populateDependenciesTree(GoTreeBuilder.java:99)
        at com.jfrog.ide.common.go.GoTreeBuilder.populateDependenciesTree(GoTreeBuilder.java:99)
        at com.jfrog.ide.common.go.GoTreeBuilder.populateDependenciesTree(GoTreeBuilder.java:99)


Same as https://github.com/jfrog/jfrog-vscode-extension/pull/44