### PR TITLE
Support colon in build name

### DIFF
--- a/src/main/java/com/jfrog/ide/common/ci/BuildGeneralInfo.java
+++ b/src/main/java/com/jfrog/ide/common/ci/BuildGeneralInfo.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.common.ci;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.Vcs;
 import org.jfrog.build.api.producerConsumer.ProducerConsumerItem;
@@ -58,5 +59,10 @@ public class BuildGeneralInfo extends GeneralInfo implements ProducerConsumerIte
     public BuildGeneralInfo vcs(Vcs vcs) {
         this.vcs = vcs;
         return this;
+    }
+
+    @Override
+    public String getArtifactId() {
+        return StringUtils.substringBeforeLast(getComponentId(), ":");
     }
 }

--- a/src/main/java/com/jfrog/ide/common/ci/XrayBuildDetailsDownloader.java
+++ b/src/main/java/com/jfrog/ide/common/ci/XrayBuildDetailsDownloader.java
@@ -105,7 +105,7 @@ public class XrayBuildDetailsDownloader extends ConsumerRunnableBase {
     }
 
     private void addResults(GeneralInfo generalInfo) {
-        BuildDependencyTree dependencyTree = new BuildDependencyTree(generalInfo.getComponentId().replace(":", "/"));
+        BuildDependencyTree dependencyTree = new BuildDependencyTree(generalInfo.getArtifactId() + "/" + generalInfo.getVersion());
         dependencyTree.setGeneralInfo(generalInfo);
         synchronized (root) {
             root.add(dependencyTree);


### PR DESCRIPTION
* The build cache file should have decoded build name. For example, 
  * Before fix: `declarative%3AdockerPull test` 
  * After fix: `declarative:dockerPull test`
* Fix an issue whereby getArtifactId returns part of the build name when the build name contains a colon. For example, when build name is `declarative:dockerPull test`:
  * Before fix: Returns "dockerPull test"
  * After fix: Returns "declarative:dockerPull test"