### PR TITLE
Bugfix - build patterns with slash doesn't encoded correctly

### DIFF
--- a/src/main/java/com/jfrog/ide/common/ci/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/ci/Utils.java
@@ -1,6 +1,8 @@
 package com.jfrog.ide.common.ci;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.codec.EncoderException;
+import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.BuildInfoProperties;
@@ -62,10 +64,13 @@ public class Utils {
      * @param buildsPattern - The build wildcard pattern to filter in Artifactory
      * @return the AQL query.
      */
-    public static String createAqlForBuildArtifacts(String buildsPattern) {
+    public static String createAqlForBuildArtifacts(String buildsPattern) throws EncoderException {
+        String encodedBuildPattern = new URLCodec().encode(buildsPattern);
+        // The following is a workaround, since Artifactory does not yet support '%' in AQL
+        encodedBuildPattern = encodedBuildPattern.replaceAll("%", "?");
         return String.format("items.find({" +
                 "\"repo\":\"artifactory-build-info\"," +
                 "\"path\":{\"$match\":\"%s\"}}" +
-                ").include(\"name\",\"repo\",\"path\",\"created\").sort({\"$desc\":[\"created\"]}).limit(100)", buildsPattern);
+                ").include(\"name\",\"repo\",\"path\",\"created\").sort({\"$desc\":[\"created\"]}).limit(100)", encodedBuildPattern);
     }
 }

--- a/src/test/java/com/jfrog/ide/common/ci/UtilsTests.java
+++ b/src/test/java/com/jfrog/ide/common/ci/UtilsTests.java
@@ -1,0 +1,28 @@
+package com.jfrog.ide.common.ci;
+
+import org.apache.commons.codec.EncoderException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.jfrog.ide.common.ci.Utils.createAqlForBuildArtifacts;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ **/
+public class UtilsTests {
+
+    @DataProvider
+    private Object[][] buildPatternsProvider() {
+        return new Object[][]{
+                {"simpleBuild", "items.find({\"repo\":\"artifactory-build-info\",\"path\":{\"$match\":\"simpleBuild\"}}).include(\"name\",\"repo\",\"path\",\"created\").sort({\"$desc\":[\"created\"]}).limit(100)"},
+                {"*", "items.find({\"repo\":\"artifactory-build-info\",\"path\":{\"$match\":\"*\"}}).include(\"name\",\"repo\",\"path\",\"created\").sort({\"$desc\":[\"created\"]}).limit(100)"},
+                {"build/with/slash", "items.find({\"repo\":\"artifactory-build-info\",\"path\":{\"$match\":\"build?2Fwith?2Fslash\"}}).include(\"name\",\"repo\",\"path\",\"created\").sort({\"$desc\":[\"created\"]}).limit(100)"},
+        };
+    }
+
+    @Test(dataProvider = "buildPatternsProvider")
+    public void testCreateAqlForBuildArtifacts(String buildPattern, String expected) throws EncoderException {
+        assertEquals(createAqlForBuildArtifacts(buildPattern), expected);
+    }
+}


### PR DESCRIPTION
Encode build name patterns to support slash in the build name. Encode `%` to `?` to bypass an issue in Artifactory.
Examples:

* `buildName` -> `buildName`
* `*` -> `*`
* `build/with/slash` -> `build?2Fwith?2Fslash`