### PR TITLE
Bugfix - npm without version throws NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.26.4'
+def buildInfoVersion = '2.29.0'
 dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-go', version: buildInfoVersion

--- a/src/main/java/com/jfrog/ide/common/utils/ArtifactoryConnectionUtils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/ArtifactoryConnectionUtils.java
@@ -23,7 +23,7 @@ public class ArtifactoryConnectionUtils {
                 SSLContextBuilder.create().loadTrustMaterial(TrustAllStrategy.INSTANCE).build() :
                 serverConfig.getSslContext();
         return new ArtifactoryManagerBuilder()
-                .setArtifactoryUrl(serverConfig.getArtifactoryUrl())
+                .setServerUrl(serverConfig.getArtifactoryUrl())
                 .setUsername(serverConfig.getUsername())
                 .setPassword(serverConfig.getPassword())
                 .setProxyConfiguration(serverConfig.getProxyConfForTargetUrl(serverConfig.getArtifactoryUrl()))


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix an issue found by @TamirHadad's - if name or version are missing in the package.json, an NPE is thrown.

This PR make the following changes:
1. Update build info to the latest version to reflect the latest changes, and include https://github.com/jfrog/build-info/pull/546 
2. When the name node is missing in package.json, show the project name as the root node of the dependency tree.