### PR TITLE
Allow excluding paths in GoScanWorkspaceCreator

### DIFF
--- a/src/main/java/com/jfrog/ide/common/go/GoScanWorkspaceCreator.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoScanWorkspaceCreator.java
@@ -5,10 +5,7 @@ import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.go.GoDriver;
 
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
 
@@ -21,12 +18,14 @@ import java.util.Map;
  * @author yahavi
  **/
 public class GoScanWorkspaceCreator implements FileVisitor<Path> {
+    private final PathMatcher exclusions;
     private final GoDriver goDriver;
     private final Path sourceDir;
     private final Path targetDir;
     private final Log logger;
 
-    public GoScanWorkspaceCreator(Path sourceDir, Path targetDir, Path goModAbsDir, Map<String, String> env, Log logger) {
+    public GoScanWorkspaceCreator(Path sourceDir, Path targetDir, Path goModAbsDir, Map<String, String> env, Log logger, String excludedPaths) {
+        this.exclusions = FileSystems.getDefault().getPathMatcher("glob:" + excludedPaths);
         this.goDriver = new GoDriver(null, env, goModAbsDir.toFile(), logger);
         this.sourceDir = sourceDir;
         this.targetDir = targetDir;
@@ -35,6 +34,9 @@ public class GoScanWorkspaceCreator implements FileVisitor<Path> {
 
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        if (exclusions.matches(dir)) {
+            return FileVisitResult.SKIP_SUBTREE;
+        }
         Path resolve = targetDir.resolve(sourceDir.relativize(dir));
         if (Files.notExists(resolve)) {
             Files.createDirectories(resolve);

--- a/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
@@ -28,17 +28,19 @@ public class GoTreeBuilder {
     private static final String[] GO_MOD_ABS_COMPONENTS = new String[]{"go.mod", "go.sum", "main.go", "utils.go"};
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final Map<String, String> env;
+    private final String excludedPaths;
     private final Path projectDir;
     private final Log logger;
 
-    public GoTreeBuilder(Path projectDir, Map<String, String> env, Log logger) {
+    public GoTreeBuilder(Path projectDir, Map<String, String> env, Log logger, String excludedPaths) {
+        this.excludedPaths = excludedPaths;
         this.projectDir = projectDir;
         this.logger = logger;
         this.env = env;
     }
 
     public DependencyTree buildTree() throws IOException {
-        File tmpDir = createGoWorkspace(projectDir, env, logger).toFile();
+        File tmpDir = createGoWorkspace().toFile();
         try {
             GoDriver goDriver = new GoDriver(null, env, tmpDir, logger);
             if (!goDriver.isInstalled()) {
@@ -59,19 +61,16 @@ public class GoTreeBuilder {
      * Copy go.mod file to a temporary directory.
      * This is necessary to bypass checksum mismatches issues in the original go.sum.
      *
-     * @param sourceDir - Go project directory
-     * @param env       - Environment variables
-     * @param logger    - The logger
      * @return the temporary directory.
      * @throws IOException in case of any I/O error.
      */
-    private Path createGoWorkspace(Path sourceDir, Map<String, String> env, Log logger) throws IOException {
+    private Path createGoWorkspace() throws IOException {
         Path targetDir = Files.createTempDirectory(null);
         Path goModAbsDir = null;
         try {
             goModAbsDir = prepareGoModAbs();
-            GoScanWorkspaceCreator goScanWorkspaceCreator = new GoScanWorkspaceCreator(sourceDir, targetDir, goModAbsDir, env, logger);
-            Files.walkFileTree(sourceDir, goScanWorkspaceCreator);
+            GoScanWorkspaceCreator goScanWorkspaceCreator = new GoScanWorkspaceCreator(projectDir, targetDir, goModAbsDir, env, logger, excludedPaths);
+            Files.walkFileTree(projectDir, goScanWorkspaceCreator);
         } finally {
             if (goModAbsDir != null) {
                 FileUtils.deleteQuietly(goModAbsDir.toFile());

--- a/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
@@ -38,7 +38,7 @@ public class GoTreeBuilderTest {
 
         try {
             Path projectDir = createProjectDir("project1", GO_ROOT.resolve("project1").toFile());
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log, "");
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log, "**/*testdata");
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {

--- a/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
@@ -38,7 +38,7 @@ public class GoTreeBuilderTest {
 
         try {
             Path projectDir = createProjectDir("project1", GO_ROOT.resolve("project1").toFile());
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log, "");
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -56,7 +56,7 @@ public class GoTreeBuilderTest {
         }};
         try {
             Path projectDir = createProjectDir("project2", GO_ROOT.resolve("project2").toFile());
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log, "");
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -74,7 +74,7 @@ public class GoTreeBuilderTest {
         }};
         try {
             Path projectDir = createProjectDir("project3", GO_ROOT.resolve("project3").toFile());
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(projectDir, null, log, "");
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -136,7 +136,7 @@ public class GoTreeBuilderTest {
         }};
         Map<String, List<String>> allDependencies = getAllDependenciesForTest();
         DependencyTree rootNode = new DependencyTree();
-        GoTreeBuilder treeBuilder = new GoTreeBuilder(Paths.get(""), null, log);
+        GoTreeBuilder treeBuilder = new GoTreeBuilder(Paths.get(""), null, log, "");
         treeBuilder.populateDependencyTree(rootNode, "my/pkg/name1", allDependencies);
         validateDependencyTreeResults(expected, rootNode, false);
     }

--- a/src/test/resources/go/project1/testdata/go.mod
+++ b/src/test/resources/go/project1/testdata/go.mod
@@ -1,0 +1,8 @@
+module badproject
+
+go 1.13
+
+require (
+    github.com/jfrog/jfrog-cli-core v999.999.999
+    github.com/jfrog/jfrog-client-go v999.999.999 // indirect
+)

--- a/src/test/resources/go/project1/testdata/main.go
+++ b/src/test/resources/go/project1/testdata/main.go
@@ -1,0 +1,10 @@
+package project1
+
+import (
+	"github.com/jfrog/jfrog-cli-core/artifactory/commands/curl"
+	"github.com/jfrog/jfrog-cli-core/common/commands"
+)
+
+func main() {
+	curl.NewRtCurlCommand(commands.CurlCommand{})
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Allow GoScanWorkspaceCreator to exclude paths. This is necessary to exclude unused test projects (i.e. files under testdata) from the Go scanner.