### PR TITLE
Allow providing the Go executable path

### DIFF
--- a/src/main/java/com/jfrog/ide/common/go/GoScanWorkspaceCreator.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoScanWorkspaceCreator.java
@@ -27,8 +27,8 @@ public class GoScanWorkspaceCreator implements FileVisitor<Path> {
     private final Path targetDir;
     private final Log logger;
 
-    public GoScanWorkspaceCreator(Path sourceDir, Path targetDir, Path goModAbsDir, Map<String, String> env, Log logger) {
-        this.goDriver = new GoDriver(null, env, goModAbsDir.toFile(), logger);
+    public GoScanWorkspaceCreator(String executablePath, Path sourceDir, Path targetDir, Path goModAbsDir, Map<String, String> env, Log logger) {
+        this.goDriver = new GoDriver(executablePath, env, goModAbsDir.toFile(), logger);
         this.sourceDir = sourceDir;
         this.targetDir = targetDir;
         this.logger = logger;

--- a/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
@@ -28,10 +28,12 @@ public class GoTreeBuilder {
     private static final String[] GO_MOD_ABS_COMPONENTS = new String[]{"go.mod", "go.sum", "main.go", "utils.go"};
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final Map<String, String> env;
+    private final String executablePath;
     private final Path projectDir;
     private final Log logger;
 
-    public GoTreeBuilder(Path projectDir, Map<String, String> env, Log logger) {
+    public GoTreeBuilder(String executablePath, Path projectDir, Map<String, String> env, Log logger) {
+        this.executablePath = executablePath;
         this.projectDir = projectDir;
         this.logger = logger;
         this.env = env;
@@ -40,7 +42,7 @@ public class GoTreeBuilder {
     public DependencyTree buildTree() throws IOException {
         File tmpDir = createGoWorkspace().toFile();
         try {
-            GoDriver goDriver = new GoDriver(null, env, tmpDir, logger);
+            GoDriver goDriver = new GoDriver(executablePath, env, tmpDir, logger);
             if (!goDriver.isInstalled()) {
                 throw new IOException("Could not scan go project dependencies, because go CLI is not in the PATH.");
             }
@@ -67,7 +69,7 @@ public class GoTreeBuilder {
         Path goModAbsDir = null;
         try {
             goModAbsDir = prepareGoModAbs();
-            GoScanWorkspaceCreator goScanWorkspaceCreator = new GoScanWorkspaceCreator(projectDir, targetDir, goModAbsDir, env, logger);
+            GoScanWorkspaceCreator goScanWorkspaceCreator = new GoScanWorkspaceCreator(executablePath, projectDir, targetDir, goModAbsDir, env, logger);
             Files.walkFileTree(projectDir, goScanWorkspaceCreator);
         } finally {
             if (goModAbsDir != null) {

--- a/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
@@ -34,7 +34,7 @@ public class GoTreeBuilderTest {
         }};
 
         try {
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(GO_ROOT.resolve("project1"), null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project1"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -51,7 +51,7 @@ public class GoTreeBuilderTest {
             put("github.com/jfrog/gocmd:0.1.12", 2);
         }};
         try {
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(GO_ROOT.resolve("project2"), null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project2"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -69,7 +69,7 @@ public class GoTreeBuilderTest {
             put("github.com/test/subproject:0.0.0-00010101000000-000000000000", 1);
         }};
         try {
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(GO_ROOT.resolve("project3"), null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project3"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -87,7 +87,7 @@ public class GoTreeBuilderTest {
             put("github.com/test/subproject:0.0.0-00010101000000-000000000000", 1);
         }};
         try {
-            GoTreeBuilder treeBuilder = new GoTreeBuilder(GO_ROOT.resolve("project4"), null, log);
+            GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project4"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
             validateDependencyTreeResults(expected, dt, true);
         } catch (IOException ex) {
@@ -149,7 +149,7 @@ public class GoTreeBuilderTest {
         }};
         Map<String, List<String>> allDependencies = getAllDependenciesForTest();
         DependencyTree rootNode = new DependencyTree();
-        GoTreeBuilder treeBuilder = new GoTreeBuilder(Paths.get(""), null, log);
+        GoTreeBuilder treeBuilder = new GoTreeBuilder(null, Paths.get(""), null, log);
         treeBuilder.populateDependencyTree(rootNode, "my/pkg/name1", allDependencies);
         validateDependencyTreeResults(expected, rootNode, false);
     }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Allow providing the Go executable path in the GoTreeBuilder. If null or empty, use the default Go executable from the system path.