### PR TITLE
CI - bugfix - loadBuild failed on build names with ':'

### DIFF
--- a/src/main/java/com/jfrog/ide/common/ci/CiManagerBase.java
+++ b/src/main/java/com/jfrog/ide/common/ci/CiManagerBase.java
@@ -15,6 +15,7 @@ import org.jfrog.build.extractor.producerConsumer.ConsumerRunnableBase;
 import org.jfrog.build.extractor.producerConsumer.ProducerConsumerExecutor;
 import org.jfrog.build.extractor.producerConsumer.ProducerRunnableBase;
 import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.GeneralInfo;
 import org.jfrog.build.extractor.scan.License;
 import org.jfrog.build.extractor.scan.Scope;
 
@@ -36,6 +37,8 @@ import static com.jfrog.ide.common.log.Utils.logError;
 import static com.jfrog.ide.common.utils.ArtifactoryConnectionUtils.createArtifactoryManagerBuilder;
 import static com.jfrog.ide.common.utils.Utils.createMapper;
 import static com.jfrog.ide.common.utils.XrayConnectionUtils.createXrayClientBuilder;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+import static org.apache.commons.lang3.StringUtils.substringBeforeLast;
 import static org.jfrog.build.client.PreemptiveHttpClientBuilder.CONNECTION_POOL_SIZE;
 
 /**
@@ -47,8 +50,8 @@ import static org.jfrog.build.client.PreemptiveHttpClientBuilder.CONNECTION_POOL
 public class CiManagerBase {
     protected DependencyTree root = new DependencyTree();
     private final ObjectMapper mapper = createMapper();
-    private final BuildsScanCache buildsCache;
     private final ServerConfig serverConfig;
+    final BuildsScanCache buildsCache;
     private final Log log;
 
     public CiManagerBase(Path cachePath, String projectName, Log log, ServerConfig serverConfig) throws IOException {
@@ -108,8 +111,10 @@ public class CiManagerBase {
         }
     }
 
-    public BuildDependencyTree loadBuildTree(String buildName, String buildNumber) throws IOException, ParseException {
+    public BuildDependencyTree loadBuildTree(GeneralInfo buildGeneralInfo) throws IOException, ParseException {
         BuildDependencyTree buildDependencyTree = new BuildDependencyTree();
+        String buildName = substringBeforeLast(buildGeneralInfo.getComponentId(), ":");
+        String buildNumber = substringAfterLast(buildGeneralInfo.getComponentId(), ":");
 
         // Load build info from cache
         Build build = buildsCache.loadBuildInfo(mapper, buildName, buildNumber);

--- a/src/test/java/com/jfrog/ide/common/ci/CiManagerBaseTest.java
+++ b/src/test/java/com/jfrog/ide/common/ci/CiManagerBaseTest.java
@@ -1,0 +1,84 @@
+package com.jfrog.ide.common.ci;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jfrog.ide.common.persistency.BuildsScanCache;
+import com.jfrog.xray.client.impl.services.details.DetailsResponseImpl;
+import com.jfrog.xray.client.services.details.DetailsResponse;
+import com.jfrog.xray.client.services.summary.Artifact;
+import org.apache.commons.io.FileUtils;
+import org.jfrog.build.api.Build;
+import org.jfrog.build.api.builder.BuildInfoBuilder;
+import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.extractor.scan.GeneralInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jfrog.ide.common.utils.Utils.createMapper;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * @author yahavi
+ **/
+public class CiManagerBaseTest {
+    private static final String BUILD_TIMESTAMP = "2021-03-17T17:08:38.989+0200";
+    private static final String BUILD_NUMBER = "1";
+
+    ObjectMapper mapper = createMapper();
+    private Path cachePath;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        cachePath = Files.createTempDirectory("testLoadBuildTree");
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirectory(cachePath.toFile());
+    }
+
+    @DataProvider(name = "buildNames")
+    private Object[][] getBuildNames() {
+        return new Object[][]{{"testBuild"}, {"test/build"}, {"test::build"}, {"test::build:"}, {"test%build"}};
+    }
+
+    @Test(dataProvider = "buildNames")
+    public void testLoadBuildTree(String buildName) throws IOException, ParseException {
+        // Create CI Manager Base
+        CiManagerBase ciManagerBase = new CiManagerBase(cachePath, "test", new NullLog(), null);
+        cacheDummyBuild(ciManagerBase, buildName);
+
+        // Load build tree
+        BuildDependencyTree buildDependencyTree = ciManagerBase.loadBuildTree(new GeneralInfo().componentId(buildName + ":" + BUILD_NUMBER));
+        assertNotNull(buildDependencyTree);
+
+        // Check results
+        assertEquals(buildDependencyTree.getUserObject(), buildName + "/" + BUILD_NUMBER);
+        GeneralInfo generalInfo = buildDependencyTree.getGeneralInfo();
+        assertNotNull(generalInfo);
+        assertEquals(generalInfo.getComponentId(), buildName + ":" + BUILD_NUMBER);
+    }
+
+    private void cacheDummyBuild(CiManagerBase ciManagerBase, String buildName) throws IOException {
+        Build build = new BuildInfoBuilder(buildName).number(BUILD_NUMBER).started(BUILD_TIMESTAMP).build();
+        ciManagerBase.buildsCache.save(mapper.writeValueAsBytes(build), buildName, BUILD_NUMBER, BuildsScanCache.Type.BUILD_INFO);
+        DetailsResponse detailsResponse = new MockDetailsResponse();
+        ciManagerBase.buildsCache.save(mapper.writeValueAsBytes(detailsResponse), buildName, BUILD_NUMBER, BuildsScanCache.Type.BUILD_SCAN_RESULTS);
+    }
+
+    private static class MockDetailsResponse extends DetailsResponseImpl {
+        @Override
+        public List<? extends Artifact> getComponents() {
+            return new ArrayList<>();
+        }
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
