### PR TITLE
CI - support long build names and numbers

### DIFF
--- a/src/main/java/com/jfrog/ide/common/persistency/BuildsScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/BuildsScanCache.java
@@ -3,6 +3,7 @@ package com.jfrog.ide.common.persistency;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jfrog.xray.client.impl.services.details.DetailsResponseImpl;
 import com.jfrog.xray.client.services.details.DetailsResponse;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.Build;
@@ -149,7 +150,7 @@ public class BuildsScanCache {
 
     private File getBuildFile(String buildName, String buildNumber, Type type) {
         String buildIdentifier = String.format("%s_%s", buildName, buildNumber);
-        String fileName = type.toString() + Base64.getEncoder().encodeToString(buildIdentifier.getBytes(StandardCharsets.UTF_8)) + ".zip";
+        String fileName = type.toString() + "_" + DigestUtils.sha256Hex(buildIdentifier) + ".zip";
         return buildsDir.resolve(fileName).toFile();
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

This PR fixes the "file name too long" error when running a CI scan on a very long build name and numbers.
The root cause was the base64 encoding of `buildName_buildNumber`. Instead, we should hash the string with Sha256, which produces a 64 characters string.

This solution is identical to https://github.com/jfrog/jfrog-cli-core/pull/244