### PR TITLE
Store CVEs in cache

### DIFF
--- a/src/main/java/com/jfrog/ide/common/ci/BuildDependencyTree.java
+++ b/src/main/java/com/jfrog/ide/common/ci/BuildDependencyTree.java
@@ -244,7 +244,7 @@ public class BuildDependencyTree extends DependencyTree {
         Enumeration<?> bfs = depthFirstEnumeration();
         while (bfs.hasMoreElements()) {
             DependencyTree node = (DependencyTree) bfs.nextElement();
-            node.setIssues(Sets.newHashSet(new org.jfrog.build.extractor.scan.Issue("", Severity.Unknown, "", null)));
+            node.setIssues(Sets.newHashSet(new org.jfrog.build.extractor.scan.Issue("", Severity.Unknown, "", null, "")));
         }
     }
 

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -7,7 +7,6 @@ import com.jfrog.xray.client.services.graph.Component;
 import com.jfrog.xray.client.services.graph.License;
 import com.jfrog.xray.client.services.graph.Violation;
 import com.jfrog.xray.client.services.graph.Vulnerability;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.scan.Artifact;
 import org.jfrog.build.extractor.scan.GeneralInfo;
@@ -17,6 +16,8 @@ import org.jfrog.build.extractor.scan.Severity;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+
+import static com.jfrog.ide.common.utils.Utils.getFirstCve;
 
 /**
  * Cache for Xray scan.
@@ -89,7 +90,7 @@ public abstract class ScanCache {
 
     private void addComponents(Map<String, ? extends Component> components, Severity severity, String summary, String packageType, List<? extends Cve> cves) {
         // Search for a CVE with ID. Due to UI limitations, we take only the first match.
-        String cveId = ListUtils.emptyIfNull(cves).stream().map(Cve::getId).filter(StringUtils::isNotBlank).findAny().orElse("");
+        String cveId = getFirstCve(cves);
         for (Map.Entry<String, ? extends Component> entry : components.entrySet()) {
             String id = StringUtils.substringAfter(entry.getKey(), "://");
             Component component = entry.getValue();

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -94,7 +94,6 @@ public abstract class ScanCache {
 
     private void addComponents(Map<String, ? extends Component> components, Severity severity, String summary, String packageType, List<? extends Cve> cves) {
         String cveId = ListUtils.emptyIfNull(cves).stream().map(Cve::getId).filter(StringUtils::isNotBlank).findAny().orElse("");
-        cveId = StringUtils.substringAfter(cveId, "CVE-");
         for (Map.Entry<String, ? extends Component> entry : components.entrySet()) {
             String id = StringUtils.substringAfter(entry.getKey(), "://");
             Component component = entry.getValue();

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
@@ -25,7 +25,7 @@ import static com.jfrog.ide.common.utils.Utils.createMapper;
 @Setter
 abstract class ScanCacheMap {
 
-    private static int CACHE_VERSION = 0;
+    private static int CACHE_VERSION = 1;
     static ObjectMapper objectMapper = createMapper();
 
     @JsonProperty("version")

--- a/src/main/java/com/jfrog/ide/common/persistency/XrayScanCacheMap.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/XrayScanCacheMap.java
@@ -18,8 +18,6 @@ import java.util.Collections;
 @Setter
 class XrayScanCacheMap extends ScanCacheMap {
 
-    private static int CACHE_VERSION = 0;
-
     XrayScanCacheMap() {
         artifactsMap = Collections.synchronizedMap(new TimeBasedMap());
     }

--- a/src/main/java/com/jfrog/ide/common/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/Utils.java
@@ -68,6 +68,7 @@ public class Utils {
             VulnerableComponents vulnerableComponents = vulnerableComponentsList.get(0);
             fixedVersions = vulnerableComponents.getFixedVersions();
         }
+        // Search for a CVE with ID. Due to UI limitations, we take only the first match.
         String cve = ListUtils.emptyIfNull(other.getCves()).stream().map(Cve::getId).filter(StringUtils::isNotBlank).findAny().orElse("");
         return new Issue(other.getDescription(), severity, other.getSummary(), fixedVersions, cve);
     }

--- a/src/main/java/com/jfrog/ide/common/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/Utils.java
@@ -3,6 +3,7 @@ package com.jfrog.ide.common.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Lists;
+import com.jfrog.xray.client.services.common.Cve;
 import com.jfrog.xray.client.services.summary.General;
 import com.jfrog.xray.client.services.summary.VulnerableComponents;
 import org.apache.commons.collections4.CollectionUtils;
@@ -67,7 +68,8 @@ public class Utils {
             VulnerableComponents vulnerableComponents = vulnerableComponentsList.get(0);
             fixedVersions = vulnerableComponents.getFixedVersions();
         }
-        return new Issue(other.getDescription(), severity, other.getSummary(), fixedVersions);
+        String cve = ListUtils.emptyIfNull(other.getCves()).stream().map(Cve::getId).filter(StringUtils::isNotBlank).findAny().orElse("");
+        return new Issue(other.getDescription(), severity, other.getSummary(), fixedVersions, cve);
     }
 
     public static Artifact getArtifact(com.jfrog.xray.client.services.summary.Artifact other) {

--- a/src/main/java/com/jfrog/ide/common/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/Utils.java
@@ -68,9 +68,7 @@ public class Utils {
             VulnerableComponents vulnerableComponents = vulnerableComponentsList.get(0);
             fixedVersions = vulnerableComponents.getFixedVersions();
         }
-        // Search for a CVE with ID. Due to UI limitations, we take only the first match.
-        String cve = ListUtils.emptyIfNull(other.getCves()).stream().map(Cve::getId).filter(StringUtils::isNotBlank).findAny().orElse("");
-        return new Issue(other.getDescription(), severity, other.getSummary(), fixedVersions, cve);
+        return new Issue(other.getDescription(), severity, other.getSummary(), fixedVersions, getFirstCve(other.getCves()));
     }
 
     public static Artifact getArtifact(com.jfrog.xray.client.services.summary.Artifact other) {
@@ -81,6 +79,20 @@ public class Utils {
         artifact.setIssues(issues);
         artifact.setLicenses(licenses);
         return artifact;
+    }
+
+    /**
+     * Search for a CVE with ID. Due to UI limitations, we take only the first match.
+     *
+     * @param cves - CVE list
+     * @return first non-empty CVE ID or an empty string.
+     */
+    public static String getFirstCve(List<? extends Cve> cves) {
+        return ListUtils.emptyIfNull(cves).stream()
+                .map(Cve::getId)
+                .filter(StringUtils::isNotBlank)
+                .findAny()
+                .orElse("");
     }
 
     /**

--- a/src/test/java/com/jfrog/ide/common/filter/Utils.java
+++ b/src/test/java/com/jfrog/ide/common/filter/Utils.java
@@ -20,7 +20,7 @@ public class Utils {
      * @return the random issue
      */
     static Issue createIssue(Severity severity) {
-        return new Issue(generateUID(), severity, generateUID(), Lists.newArrayList());
+        return new Issue(generateUID(), severity, generateUID(), Lists.newArrayList(), generateUID());
     }
 
     /**

--- a/src/test/java/com/jfrog/ide/common/persistency/ScanCacheTest.java
+++ b/src/test/java/com/jfrog/ide/common/persistency/ScanCacheTest.java
@@ -135,13 +135,13 @@ public class ScanCacheTest {
 
             // Read from disk and expect no errors - But empty cache
             scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
-            Assert.assertEquals(scanCache.getScanCacheMap().getVersion(), 0);
+            Assert.assertEquals(scanCache.getScanCacheMap().getVersion(), 1);
             Assert.assertTrue(scanCache.getScanCacheMap().getArtifactsMap().isEmpty());
 
             // Write and check again
             scanCache.write();
             scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
-            Assert.assertEquals(scanCache.getScanCacheMap().getVersion(), 0);
+            Assert.assertEquals(scanCache.getScanCacheMap().getVersion(), 1);
             Assert.assertTrue(scanCache.getScanCacheMap().getArtifactsMap().isEmpty());
         } catch (IOException e) {
             Assert.fail(e.getMessage());


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Store CVEs in cache and increase cache version from 0 to 1, to make sure the cache will be initialized.
