### PR TITLE
Allow building Go dependency tree with errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.31.2'
+def buildInfoVersion = '2.32.x-SNAPSHOT'
 dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-go', version: buildInfoVersion

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,15 @@ repositories {
     maven {
         url "https://releases.jfrog.io/artifactory/oss-releases"
     }
+    maven {
+        url "https://releases.jfrog.io/artifactory/oss-snapshots"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
 }
 
-def buildInfoVersion = '2.32.x-SNAPSHOT'
+def buildInfoVersion = '2.32.3'
 dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-go', version: buildInfoVersion


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Depends on:
* https://github.com/jfrog/build-info/pull/577

In some cases we see that running `go list` on some Go packages may fail. We should allow ignoring the errors in such cases and build the Go dependency tree, even if partial.