### PR TITLE
Add exporter, support ignore URL and vuln references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.13'
     implementation group: 'commons-io', name: 'commons-io', version: '2.9.0'
+    implementation group: 'com.opencsv', name: 'opencsv', version: '5.5.2'
 
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.12'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.12'

--- a/src/main/java/com/jfrog/ide/common/ci/BuildDependencyTree.java
+++ b/src/main/java/com/jfrog/ide/common/ci/BuildDependencyTree.java
@@ -36,6 +36,7 @@ public class BuildDependencyTree extends DependencyTree {
 
     public BuildDependencyTree(Object userObject) {
         super(userObject);
+        setMetadata(true);
     }
 
     /**
@@ -59,6 +60,7 @@ public class BuildDependencyTree extends DependencyTree {
                     .componentId(module.getId())
                     .pkgType(module.getType());
             DependencyTree moduleNode = new DependencyTree(module.getId());
+            moduleNode.setMetadata(true);
             moduleNode.setGeneralInfo(moduleGeneralInfo);
 
             // Populate artifacts
@@ -219,7 +221,7 @@ public class BuildDependencyTree extends DependencyTree {
                 buildArtifact.setIssues(artifact.getIssues().stream()
                         .map(com.jfrog.ide.common.utils.Utils::toIssue).collect(Collectors.toSet()));
             }
-            if (artifact.getLicenses() != null) {
+            if (CollectionUtils.isNotEmpty(artifact.getLicenses())) {
                 buildArtifact.setLicenses(artifact.getLicenses().stream()
                         .map(com.jfrog.ide.common.utils.Utils::toLicense).collect(Collectors.toSet()));
             }

--- a/src/main/java/com/jfrog/ide/common/ci/BuildDependencyTree.java
+++ b/src/main/java/com/jfrog/ide/common/ci/BuildDependencyTree.java
@@ -17,10 +17,7 @@ import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.scan.*;
 
 import java.text.ParseException;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.jfrog.ide.common.ci.Utils.*;
@@ -245,7 +242,8 @@ public class BuildDependencyTree extends DependencyTree {
         Enumeration<?> bfs = depthFirstEnumeration();
         while (bfs.hasMoreElements()) {
             DependencyTree node = (DependencyTree) bfs.nextElement();
-            node.setIssues(Sets.newHashSet(new org.jfrog.build.extractor.scan.Issue("", Severity.Unknown, "", null, "")));
+            node.setIssues(Sets.newHashSet(new org.jfrog.build.extractor.scan.Issue("", Severity.Unknown, "",
+                    Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), "")));
         }
     }
 

--- a/src/main/java/com/jfrog/ide/common/ci/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/ci/Utils.java
@@ -31,6 +31,7 @@ public class Utils {
     public static DependencyTree createDependenciesNode(String moduleId) {
         DependencyTree artifactsNode = new DependencyTree(DEPENDENCIES_NODE);
         GeneralInfo artifactsGeneralInfo = new GeneralInfo().componentId(moduleId).pkgType("Module dependencies");
+        artifactsNode.setMetadata(true);
         artifactsNode.setGeneralInfo(artifactsGeneralInfo);
         return artifactsNode;
     }
@@ -38,6 +39,7 @@ public class Utils {
     public static DependencyTree createArtifactsNode(String moduleId) {
         DependencyTree artifactsNode = new DependencyTree(ARTIFACTS_NODE);
         GeneralInfo artifactsGeneralInfo = new GeneralInfo().componentId(moduleId).pkgType("Module artifacts");
+        artifactsNode.setMetadata(true);
         artifactsNode.setGeneralInfo(artifactsGeneralInfo);
         return artifactsNode;
     }

--- a/src/main/java/com/jfrog/ide/common/exporter/Exporter.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/Exporter.java
@@ -78,8 +78,10 @@ public abstract class Exporter {
         for (Issue issue : node.getIssues()) {
             ExportableVulnerability exportable = exportableVulnerabilities.get(issue.getIssueId());
             if (exportable == null) {
+                // ExportableVulnerability is new. Add it to the map.
                 exportableVulnerabilities.put(issue.getIssueId(), createExportableVulnerability(node, issue));
             } else {
+                // ExportableVulnerability already exists in the map, Append the direct dependency to it.
                 exportable.appendDirectDependency(node);
             }
         }

--- a/src/main/java/com/jfrog/ide/common/exporter/Exporter.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/Exporter.java
@@ -1,0 +1,118 @@
+package com.jfrog.ide.common.exporter;
+
+import com.jfrog.ide.common.exporter.exportable.ExportableViolatedLicense;
+import com.jfrog.ide.common.exporter.exportable.ExportableVulnerability;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.Issue;
+import org.jfrog.build.extractor.scan.License;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author yahavi
+ **/
+public abstract class Exporter {
+    private final DependencyTree root;
+
+    public Exporter(DependencyTree root) {
+        this.root = root;
+    }
+
+    /**
+     * Generate vulnerabilities report that may be exported to a file.
+     *
+     * @return vulnerabilities report text.
+     * @throws Exception in case of any unexpected error.
+     */
+    public abstract String generateVulnerabilitiesReport() throws Exception;
+
+    /**
+     * Generate violated licenses report that may be exported to a file.
+     *
+     * @return violated licenses report text.
+     * @throws Exception in case of any unexpected error.
+     */
+    public abstract String generateViolatedLicensesReport() throws Exception;
+
+    /**
+     * Create a single exportable vulnerability.
+     *
+     * @param directDependency - The direct dependency ID in the dependency tree
+     * @param issue            - The issue
+     * @return a single exportable vulnerability.
+     */
+    protected abstract ExportableVulnerability createExportableVulnerability(DependencyTree directDependency, Issue issue);
+
+    /**
+     * Create a single exportable violated license.
+     *
+     * @param directDependency - The direct dependency ID in the dependency tree
+     * @param violatedLicense  - The violated license
+     * @return a single exportable violated license.
+     */
+    protected abstract ExportableViolatedLicense createExportableViolatedLicense(DependencyTree directDependency, License violatedLicense);
+
+    /**
+     * Collect the exportable vulnerabilities to export.
+     *
+     * @return the exportable vulnerabilities to export.
+     */
+    protected Collection<ExportableVulnerability> collectVulnerabilities() {
+        Map<String, ExportableVulnerability> exportableVulnerabilities = new HashMap<>();
+        populateExportableVulnerabilities(root, exportableVulnerabilities);
+        return exportableVulnerabilities.values();
+    }
+
+    private void populateExportableVulnerabilities(DependencyTree node,
+                                                   Map<String, ExportableVulnerability> exportableVulnerabilities) {
+        if (node.isMetadata()) {
+            // Node is an ancestor of a direct dependency
+            for (DependencyTree child : node.getChildren()) {
+                populateExportableVulnerabilities(child, exportableVulnerabilities);
+            }
+            return;
+        }
+        // Node is a direct dependency
+        for (Issue issue : node.getIssues()) {
+            ExportableVulnerability exportable = exportableVulnerabilities.get(issue.getIssueId());
+            if (exportable == null) {
+                exportableVulnerabilities.put(issue.getIssueId(), createExportableVulnerability(node, issue));
+            } else {
+                exportable.appendDirectDependency(node);
+            }
+        }
+    }
+
+    /**
+     * Collect the exportable violated licenses to export.
+     *
+     * @return the exportable violated licenses to export.
+     */
+    protected Collection<ExportableViolatedLicense> collectViolatedLicenses() {
+        Map<String, ExportableViolatedLicense> exportableViolatedLicenses = new HashMap<>();
+        populateExportableViolatedLicenses(root, exportableViolatedLicenses);
+        return exportableViolatedLicenses.values();
+    }
+
+    private void populateExportableViolatedLicenses(DependencyTree node,
+                                                    Map<String, ExportableViolatedLicense> exportableViolatedLicenses) {
+        if (node.isMetadata()) {
+            // Node is an ancestor of a direct dependency
+            for (DependencyTree child : node.getChildren()) {
+                populateExportableViolatedLicenses(child, exportableViolatedLicenses);
+            }
+            return;
+        }
+        // Node is a direct dependency
+        for (License violatedLicense : node.getViolatedLicenses()) {
+            ExportableViolatedLicense exportable = exportableViolatedLicenses.get(violatedLicense.getName());
+            if (exportable == null) {
+                exportableViolatedLicenses.put(violatedLicense.getName(), createExportableViolatedLicense(node, violatedLicense));
+            } else {
+                exportable.appendDirectDependency(node);
+            }
+        }
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/exporter/csv/CsvExporter.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/csv/CsvExporter.java
@@ -1,0 +1,100 @@
+package com.jfrog.ide.common.exporter.csv;
+
+import com.google.common.collect.Lists;
+import com.jfrog.ide.common.exporter.Exporter;
+import com.jfrog.ide.common.exporter.exportable.ExportableViolatedLicense;
+import com.jfrog.ide.common.exporter.exportable.ExportableVulnerability;
+import com.opencsv.bean.HeaderColumnNameMappingStrategy;
+import com.opencsv.bean.HeaderColumnNameMappingStrategyBuilder;
+import com.opencsv.bean.StatefulBeanToCsv;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import com.opencsv.exceptions.CsvDataTypeMismatchException;
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
+import org.apache.commons.collections4.comparators.FixedOrderComparator;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.Issue;
+import org.jfrog.build.extractor.scan.License;
+import org.jfrog.build.extractor.scan.Severity;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author yahavi
+ **/
+public class CsvExporter extends Exporter {
+    static final String SEVERITY_COL = "SEVERITY";
+    static final String IMPACTED_DEPENDENCY_COL = "IMPACTED DEPENDENCY";
+    static final String IMPACTED_DEPENDENCY_VERSION_COL = "VERSION";
+    static final String TYPE_COL = "TYPE";
+    static final String FIXED_VERSION_COL = "FIXED VERSIONS";
+    static final String DIRECT_DEPENDENCIES_COL = "DIRECT DEPENDENCIES";
+    static final String CVES_COL = "CVES";
+    static final String CVSS_V2_COL = "CVSS V2";
+    static final String CVSS_V3_COL = "CVSS V3";
+    static final String ISSUE_ID_COL = "ISSUE ID";
+    static final String SUMMARY_COL = "SUMMARY";
+
+    static final String LICENSE_NAME_COL = "LICENSE";
+
+    private static final List<String> COLUMNS_ORDER = Lists.newArrayList(
+            LICENSE_NAME_COL, SEVERITY_COL, IMPACTED_DEPENDENCY_COL, IMPACTED_DEPENDENCY_VERSION_COL, TYPE_COL,
+            FIXED_VERSION_COL, DIRECT_DEPENDENCIES_COL, CVES_COL, CVSS_V2_COL, CVSS_V3_COL,
+            ISSUE_ID_COL, SUMMARY_COL);
+
+    public CsvExporter(DependencyTree root) {
+        super(root);
+    }
+
+    @Override
+    public String generateVulnerabilitiesReport() throws CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
+        Writer writer = new StringWriter();
+        StatefulBeanToCsv<CsvVulnerabilityRow> csvWriter = createCsvWriter(CsvVulnerabilityRow.class, writer);
+
+        List<CsvVulnerabilityRow> issueRows = collectVulnerabilities().stream()
+                .map(exportableIssue -> (CsvVulnerabilityRow) exportableIssue)
+                .sorted(Comparator.comparing(issueRow -> Severity.valueOf(issueRow.getSeverity()), Comparator.reverseOrder()))
+                .collect(Collectors.toList());
+        for (CsvVulnerabilityRow issue : issueRows) {
+            csvWriter.write(issue);
+        }
+
+        return writer.toString();
+    }
+
+    @Override
+    public String generateViolatedLicensesReport() throws CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
+        Writer writer = new StringWriter();
+        StatefulBeanToCsv<CsvViolatedViolatedLicenseRow> csvWriter = createCsvWriter(CsvViolatedViolatedLicenseRow.class, writer);
+
+        List<CsvViolatedViolatedLicenseRow> violatedLicenseRows = collectViolatedLicenses().stream()
+                .map(exportableViolatedLicense -> (CsvViolatedViolatedLicenseRow) exportableViolatedLicense)
+                .sorted(Comparator.comparing(CsvViolatedViolatedLicenseRow::getName))
+                .collect(Collectors.toList());
+        for (CsvViolatedViolatedLicenseRow violatedLicenseRow : violatedLicenseRows) {
+            csvWriter.write(violatedLicenseRow);
+        }
+
+        return writer.toString();
+    }
+
+    private <T> StatefulBeanToCsv<T> createCsvWriter(Class<T> rowClass, Writer writer) {
+        HeaderColumnNameMappingStrategy<T> strategy = new HeaderColumnNameMappingStrategyBuilder<T>().build();
+        strategy.setType(rowClass);
+        strategy.setColumnOrderOnWrite(new FixedOrderComparator<>(COLUMNS_ORDER));
+        return new StatefulBeanToCsvBuilder<T>(writer).withMappingStrategy(strategy).build();
+    }
+
+    @Override
+    protected ExportableVulnerability createExportableVulnerability(DependencyTree directDependency, Issue issue) {
+        return new CsvVulnerabilityRow(directDependency, issue);
+    }
+
+    @Override
+    protected ExportableViolatedLicense createExportableViolatedLicense(DependencyTree directDependency, License violatedLicense) {
+        return new CsvViolatedViolatedLicenseRow(directDependency, violatedLicense);
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/exporter/csv/CsvExporter.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/csv/CsvExporter.java
@@ -16,6 +16,7 @@ import org.jfrog.build.extractor.scan.Issue;
 import org.jfrog.build.extractor.scan.License;
 import org.jfrog.build.extractor.scan.Severity;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Comparator;
@@ -50,35 +51,38 @@ public class CsvExporter extends Exporter {
     }
 
     @Override
-    public String generateVulnerabilitiesReport() throws CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
-        Writer writer = new StringWriter();
-        StatefulBeanToCsv<CsvVulnerabilityRow> csvWriter = createCsvWriter(CsvVulnerabilityRow.class, writer);
+    public String generateVulnerabilitiesReport() throws CsvRequiredFieldEmptyException, CsvDataTypeMismatchException, IOException {
+        try (Writer writer = new StringWriter()) {
+            StatefulBeanToCsv<CsvVulnerabilityRow> csvWriter = createCsvWriter(CsvVulnerabilityRow.class, writer);
 
-        List<CsvVulnerabilityRow> issueRows = collectVulnerabilities().stream()
-                .map(exportableIssue -> (CsvVulnerabilityRow) exportableIssue)
-                .sorted(Comparator.comparing(issueRow -> Severity.valueOf(issueRow.getSeverity()), Comparator.reverseOrder()))
-                .collect(Collectors.toList());
-        for (CsvVulnerabilityRow issue : issueRows) {
-            csvWriter.write(issue);
+            List<CsvVulnerabilityRow> issueRows = collectVulnerabilities().stream()
+                    .map(exportableIssue -> (CsvVulnerabilityRow) exportableIssue)
+                    .sorted(Comparator.comparing(issueRow -> Severity.valueOf(issueRow.getSeverity()), Comparator.reverseOrder()))
+                    .collect(Collectors.toList());
+            for (CsvVulnerabilityRow issue : issueRows) {
+                csvWriter.write(issue);
+            }
+
+            return writer.toString();
         }
 
-        return writer.toString();
     }
 
     @Override
-    public String generateViolatedLicensesReport() throws CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
-        Writer writer = new StringWriter();
-        StatefulBeanToCsv<CsvViolatedViolatedLicenseRow> csvWriter = createCsvWriter(CsvViolatedViolatedLicenseRow.class, writer);
+    public String generateViolatedLicensesReport() throws CsvRequiredFieldEmptyException, CsvDataTypeMismatchException, IOException {
+        try (Writer writer = new StringWriter()) {
+            StatefulBeanToCsv<CsvViolatedViolatedLicenseRow> csvWriter = createCsvWriter(CsvViolatedViolatedLicenseRow.class, writer);
 
-        List<CsvViolatedViolatedLicenseRow> violatedLicenseRows = collectViolatedLicenses().stream()
-                .map(exportableViolatedLicense -> (CsvViolatedViolatedLicenseRow) exportableViolatedLicense)
-                .sorted(Comparator.comparing(CsvViolatedViolatedLicenseRow::getName))
-                .collect(Collectors.toList());
-        for (CsvViolatedViolatedLicenseRow violatedLicenseRow : violatedLicenseRows) {
-            csvWriter.write(violatedLicenseRow);
+            List<CsvViolatedViolatedLicenseRow> violatedLicenseRows = collectViolatedLicenses().stream()
+                    .map(exportableViolatedLicense -> (CsvViolatedViolatedLicenseRow) exportableViolatedLicense)
+                    .sorted(Comparator.comparing(CsvViolatedViolatedLicenseRow::getName))
+                    .collect(Collectors.toList());
+            for (CsvViolatedViolatedLicenseRow violatedLicenseRow : violatedLicenseRows) {
+                csvWriter.write(violatedLicenseRow);
+            }
+
+            return writer.toString();
         }
-
-        return writer.toString();
     }
 
     private <T> StatefulBeanToCsv<T> createCsvWriter(Class<T> rowClass, Writer writer) {

--- a/src/main/java/com/jfrog/ide/common/exporter/csv/CsvViolatedViolatedLicenseRow.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/csv/CsvViolatedViolatedLicenseRow.java
@@ -1,0 +1,48 @@
+package com.jfrog.ide.common.exporter.csv;
+
+import com.jfrog.ide.common.exporter.exportable.ExportableViolatedLicense;
+import com.opencsv.bean.CsvBindAndSplitByName;
+import com.opencsv.bean.CsvBindByName;
+import lombok.Getter;
+import lombok.Setter;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.License;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jfrog.ide.common.exporter.csv.CsvExporter.*;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+/**
+ * @author yahavi
+ **/
+@Setter
+@SuppressWarnings("unused")
+public class CsvViolatedViolatedLicenseRow extends ExportableViolatedLicense {
+    CsvViolatedViolatedLicenseRow(DependencyTree directDependency, License violatedLicense) {
+        super(directDependency, violatedLicense);
+    }
+
+    @Getter
+    @CsvBindByName(column = LICENSE_NAME_COL)
+    private String name;
+
+    @CsvBindByName(column = IMPACTED_DEPENDENCY_COL)
+    private String impactedDependencyName;
+
+    @CsvBindByName(column = IMPACTED_DEPENDENCY_VERSION_COL)
+    private String impactedDependencyVersion;
+
+    @CsvBindByName(column = TYPE_COL)
+    private String type;
+
+    @CsvBindAndSplitByName(column = DIRECT_DEPENDENCIES_COL, elementType = String.class, writeDelimiter = ";")
+    private List<String> directDependencies;
+
+    @Override
+    public void addDirectDependency(String directDependency) {
+        directDependencies = defaultIfNull(directDependencies, new ArrayList<>());
+        directDependencies.add(directDependency);
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/exporter/csv/CsvVulnerabilityRow.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/csv/CsvVulnerabilityRow.java
@@ -1,0 +1,79 @@
+package com.jfrog.ide.common.exporter.csv;
+
+import com.jfrog.ide.common.exporter.exportable.ExportableVulnerability;
+import com.opencsv.bean.CsvBindAndSplitByName;
+import com.opencsv.bean.CsvBindByName;
+import lombok.Getter;
+import lombok.Setter;
+import org.jfrog.build.extractor.scan.Cve;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.Issue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jfrog.ide.common.exporter.csv.CsvExporter.*;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+/**
+ * @author yahavi
+ **/
+@Setter
+@SuppressWarnings("unused")
+public class CsvVulnerabilityRow extends ExportableVulnerability {
+    CsvVulnerabilityRow(DependencyTree directDependency, Issue issue) {
+        super(directDependency, issue);
+    }
+
+    @Getter
+    @CsvBindByName(column = SEVERITY_COL)
+    private String severity;
+
+    @CsvBindByName(column = IMPACTED_DEPENDENCY_COL)
+    private String impactedDependencyName;
+
+    @CsvBindByName(column = IMPACTED_DEPENDENCY_VERSION_COL)
+    private String impactedDependencyVersion;
+
+    @CsvBindByName(column = TYPE_COL)
+    private String type;
+
+    @CsvBindAndSplitByName(column = FIXED_VERSION_COL, elementType = String.class, writeDelimiter = ";")
+    private List<String> fixedVersions;
+
+    @CsvBindAndSplitByName(column = DIRECT_DEPENDENCIES_COL, elementType = String.class, writeDelimiter = ";")
+    private List<String> directDependencies;
+
+    @CsvBindAndSplitByName(column = CVES_COL, elementType = String.class, writeDelimiter = ";")
+    private List<String> cves;
+
+    @CsvBindAndSplitByName(column = CVSS_V2_COL, elementType = String.class, writeDelimiter = ";")
+    private List<String> cvssV2;
+
+    @CsvBindAndSplitByName(column = CVSS_V3_COL, elementType = String.class, writeDelimiter = ";")
+    private List<String> cvssV3;
+
+    @CsvBindByName(column = ISSUE_ID_COL)
+    private String issueId;
+
+    @CsvBindByName(column = SUMMARY_COL)
+    private String summary;
+
+    @Override
+    public void addDirectDependency(String directDependency) {
+        directDependencies = defaultIfNull(directDependencies, new ArrayList<>());
+        directDependencies.add(directDependency);
+    }
+
+    @Override
+    public void setCves(List<Cve> cves) {
+        this.cves = defaultIfNull(this.cves, new ArrayList<>());
+        cvssV2 = defaultIfNull(cvssV2, new ArrayList<>());
+        cvssV3 = defaultIfNull(cvssV3, new ArrayList<>());
+        for (Cve cve : cves) {
+            this.cves.add(cve.getCveId());
+            cvssV2.add(cve.getCvssV1());
+            cvssV3.add(cve.getCvssV2());
+        }
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/exporter/exportable/ExportableComponent.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/exportable/ExportableComponent.java
@@ -1,0 +1,37 @@
+package com.jfrog.ide.common.exporter.exportable;
+
+import org.jfrog.build.extractor.scan.DependencyTree;
+
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+import static org.apache.commons.lang3.StringUtils.substringBeforeLast;
+
+/**
+ * Represents the shared code between ExportableVulnerability and ExportableViolatedLicense.
+ *
+ * @author yahavi
+ **/
+abstract class ExportableComponent {
+    protected ExportableComponent(DependencyTree directDependency, String component) {
+        setImpactedDependency(component);
+        DependencyTree parent = (DependencyTree) directDependency.getParent();
+        setType(parent.getGeneralInfo().getPkgType());
+        appendDirectDependency(directDependency);
+    }
+
+    public abstract void setImpactedDependencyName(String impactedDependencyName);
+
+    public abstract void setImpactedDependencyVersion(String impactedDependencyVersion);
+
+    public abstract void setType(String type);
+
+    public abstract void addDirectDependency(String directDependency);
+
+    public void setImpactedDependency(String impactedDependency) {
+        setImpactedDependencyName(substringBeforeLast(impactedDependency, ":"));
+        setImpactedDependencyVersion(substringAfterLast(impactedDependency, ":"));
+    }
+
+    public void appendDirectDependency(DependencyTree directDependency) {
+        addDirectDependency(directDependency.getGeneralInfo().getComponentId());
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/exporter/exportable/ExportableViolatedLicense.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/exportable/ExportableViolatedLicense.java
@@ -1,0 +1,18 @@
+package com.jfrog.ide.common.exporter.exportable;
+
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.License;
+
+/**
+ * Represents a single exportable violated license.
+ *
+ * @author yahavi
+ **/
+public abstract class ExportableViolatedLicense extends ExportableComponent {
+    protected ExportableViolatedLicense(DependencyTree directDependency, License license) {
+        super(directDependency, license.getComponent());
+        setName(license.getName());
+    }
+
+    public abstract void setName(String name);
+}

--- a/src/main/java/com/jfrog/ide/common/exporter/exportable/ExportableVulnerability.java
+++ b/src/main/java/com/jfrog/ide/common/exporter/exportable/ExportableVulnerability.java
@@ -1,0 +1,33 @@
+package com.jfrog.ide.common.exporter.exportable;
+
+import org.jfrog.build.extractor.scan.Cve;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.Issue;
+
+import java.util.List;
+
+/**
+ * Represents a single exportable vulnerability.
+ *
+ * @author yahavi
+ **/
+public abstract class ExportableVulnerability extends ExportableComponent {
+    protected ExportableVulnerability(DependencyTree directDependency, Issue issue) {
+        super(directDependency, issue.getComponent());
+        setSeverity(issue.getSeverity().getSeverityName());
+        setFixedVersions(issue.getFixedVersions());
+        setCves(issue.getCves());
+        setIssueId(issue.getIssueId());
+        setSummary(issue.getSummary());
+    }
+
+    public abstract void setSeverity(String severity);
+
+    public abstract void setFixedVersions(List<String> fixedVersions);
+
+    public abstract void setCves(List<Cve> cves);
+
+    public abstract void setIssueId(String issueId);
+
+    public abstract void setSummary(String summary);
+}

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -14,12 +14,9 @@ import org.jfrog.build.extractor.scan.Severity;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import static com.jfrog.ide.common.utils.Utils.getFirstCve;
+import static com.jfrog.ide.common.utils.Utils.extractCves;
 
 /**
  * Cache for Xray scan.
@@ -74,11 +71,13 @@ public abstract class ScanCache {
 
     public void add(Vulnerability vulnerability) {
         // Search for a CVE with ID. Due to UI limitations, we take only the first match.
-        String cveId = getFirstCve(vulnerability.getCves());
+        List<String> cves = extractCves(vulnerability.getCves());
         for (Map.Entry<String, ? extends Component> entry : vulnerability.getComponents().entrySet()) {
             String id = StringUtils.substringAfter(entry.getKey(), "://");
             Component component = entry.getValue();
-            Issue issue = new Issue(vulnerability.getIssueId(), Severity.valueOf(vulnerability.getSeverity()), StringUtils.defaultIfBlank(vulnerability.getSummary(), "N/A"), component.getFixedVersions(), cveId);
+            Issue issue = new Issue(vulnerability.getIssueId(), Severity.valueOf(vulnerability.getSeverity()),
+                    StringUtils.defaultIfBlank(vulnerability.getSummary(), "N/A"),
+                    component.getFixedVersions(), cves, vulnerability.getReferences(), vulnerability.getIgnoreUrl());
 
             if (contains(id)) {
                 Artifact artifact = get(id);

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
@@ -25,7 +25,7 @@ import static com.jfrog.ide.common.utils.Utils.createMapper;
 @Setter
 abstract class ScanCacheMap {
 
-    static int CACHE_VERSION = 2;
+    static int CACHE_VERSION = 3;
     static ObjectMapper objectMapper = createMapper();
 
     @JsonProperty("version")

--- a/src/main/java/com/jfrog/ide/common/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/Utils.java
@@ -12,10 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.scan.*;
 
 import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
@@ -68,7 +65,8 @@ public class Utils {
             VulnerableComponents vulnerableComponents = vulnerableComponentsList.get(0);
             fixedVersions = vulnerableComponents.getFixedVersions();
         }
-        return new Issue(other.getIssueId(), severity, other.getSummary(), fixedVersions, getFirstCve(other.getCves()));
+        return new Issue(other.getIssueId(), severity, other.getSummary(), fixedVersions, extractCves(other.getCves()),
+                Collections.emptyList(), "");
     }
 
     public static Artifact getArtifact(com.jfrog.xray.client.services.summary.Artifact other) {
@@ -87,12 +85,11 @@ public class Utils {
      * @param cves - CVE list
      * @return first non-empty CVE ID or an empty string.
      */
-    public static String getFirstCve(List<? extends Cve> cves) {
+    public static List<String> extractCves(List<? extends Cve> cves) {
         return ListUtils.emptyIfNull(cves).stream()
                 .map(Cve::getId)
                 .filter(StringUtils::isNotBlank)
-                .findAny()
-                .orElse("");
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/common/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
 
     public static License toLicense(com.jfrog.xray.client.services.summary.License other) {
         List<String> moreInfoUrl = Lists.newArrayList(ListUtils.emptyIfNull(other.moreInfoUrl()));
-        return new License(Lists.newArrayList(other.getComponents()), other.getFullName(), other.getName(), moreInfoUrl);
+        return new License(other.getFullName(), other.getName(), moreInfoUrl);
     }
 
     public static Issue toIssue(com.jfrog.xray.client.services.summary.Issue other) {
@@ -65,7 +65,7 @@ public class Utils {
             VulnerableComponents vulnerableComponents = vulnerableComponentsList.get(0);
             fixedVersions = vulnerableComponents.getFixedVersions();
         }
-        return new Issue(other.getIssueId(), severity, other.getSummary(), fixedVersions, extractCves(other.getCves()),
+        return new Issue(other.getIssueId(), severity, other.getSummary(), fixedVersions, toCves(other.getCves()),
                 Collections.emptyList(), "");
     }
 
@@ -80,15 +80,14 @@ public class Utils {
     }
 
     /**
-     * Search for a CVE with ID. Due to UI limitations, we take only the first match.
+     * Convert list of {@link Cve} to list of {@link org.jfrog.build.extractor.scan.Cve}
      *
      * @param cves - CVE list
      * @return first non-empty CVE ID or an empty string.
      */
-    public static List<String> extractCves(List<? extends Cve> cves) {
+    public static List<org.jfrog.build.extractor.scan.Cve> toCves(List<? extends Cve> cves) {
         return ListUtils.emptyIfNull(cves).stream()
-                .map(Cve::getId)
-                .filter(StringUtils::isNotBlank)
+                .map(clientCve -> new org.jfrog.build.extractor.scan.Cve(clientCve.getId(), clientCve.getCvssV2Score(), clientCve.getCvssV3Score()))
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/com/jfrog/ide/common/exporter/ExporterTest.java
+++ b/src/test/java/com/jfrog/ide/common/exporter/ExporterTest.java
@@ -1,0 +1,127 @@
+package com.jfrog.ide.common.exporter;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.jfrog.ide.common.exporter.csv.CsvExporter;
+import org.apache.commons.io.FileUtils;
+import org.jfrog.build.extractor.scan.*;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ **/
+public class ExporterTest {
+    private static final Path EXPORTER_RESULTS = Paths.get(".").toAbsolutePath().normalize().resolve(Paths.get("src", "test", "resources", "exporter"));
+    private static final File EXPECTED_ISSUES_CSV = EXPORTER_RESULTS.resolve("issues.csv").toFile();
+    private static final File EXPECTED_VIOLATED_LICENSES_CSV = EXPORTER_RESULTS.resolve("violatedLicenses.csv").toFile();
+
+    @Test
+    public void testGenerateEmptyIssuesReport() throws Exception {
+        Exporter exporter = new CsvExporter(new DependencyTree());
+        assertEquals("", exporter.generateVulnerabilitiesReport());
+    }
+
+    @Test
+    public void testGenerateIssuesReport() throws Exception {
+        String expected = FileUtils.readFileToString(EXPECTED_ISSUES_CSV, StandardCharsets.UTF_8);
+        Exporter exporter = new CsvExporter(createTestTree());
+        assertEquals(exporter.generateVulnerabilitiesReport(), expected);
+    }
+
+    @Test
+    public void testGenerateEmptyViolatedLicensesReport() throws Exception {
+        Exporter exporter = new CsvExporter(new DependencyTree());
+        assertEquals("", exporter.generateViolatedLicensesReport());
+    }
+
+    @Test
+    public void testGenerateViolatedLicenseReport() throws Exception {
+        String expected = FileUtils.readFileToString(EXPECTED_VIOLATED_LICENSES_CSV, StandardCharsets.UTF_8);
+        Exporter exporter = new CsvExporter(createTestTree());
+        assertEquals(exporter.generateViolatedLicensesReport(), expected);
+    }
+
+    /**
+     * Create test tree populated with vulnerabilities and violated licenses.
+     *
+     * @return test tree.
+     */
+    private DependencyTree createTestTree() {
+        DependencyTree root = new DependencyTree();
+        root.setGeneralInfo(new GeneralInfo().componentId("root:1.0.0").pkgType("Go"));
+        root.setMetadata(true);
+
+        // Create first node
+        DependencyTree node1 = new DependencyTree("node-1:1.0.0");
+        node1.setGeneralInfo(new GeneralInfo().componentId("node-1:1.0.0"));
+        root.add(node1);
+
+        // Create second node
+        DependencyTree node2 = new DependencyTree("node-2:1.1.0");
+        node2.setGeneralInfo(new GeneralInfo().componentId("node-2:1.1.0"));
+        root.add(node2);
+
+        // Populate nodes with vulnerabilities and violated licenses.
+        addVulnerabilities(node1, node2);
+        addViolatedLicenses(node1, node2);
+
+        return root;
+    }
+
+    /**
+     * Add some vulnerabilities to node1 and node 2.
+     *
+     * @param node1 - The first node
+     * @param node2 - The second node
+     */
+    private void addVulnerabilities(DependencyTree node1, DependencyTree node2) {
+        // Create 3 issues
+        Issue issue1 = new Issue("XRAY-1", Severity.Critical, "Issue 1 summary",
+                Lists.newArrayList("2.0.0", "3.0.0"),
+                Lists.newArrayList(new Cve("CVE-1", "8.0", "9.0"), new Cve("CVE-11", "", "9.1")),
+                Collections.emptyList(), "");
+        issue1.setComponent("impacted-1:1.0.0");
+        Issue issue2 = new Issue("XRAY-2", Severity.Low, "Issue 2 summary",
+                Lists.newArrayList("1.0.0"),
+                Lists.newArrayList(new Cve("CVE-2", "7.0", "8.0")),
+                Collections.emptyList(), "");
+        issue2.setComponent("impacted-2:1.0.0");
+        Issue issue3 = new Issue("XRAY-3", Severity.High, "Issue 3 summary",
+                Lists.newArrayList("4.0.0"),
+                Lists.newArrayList(new Cve("CVE-3", "7.0", "8.0")),
+                Collections.emptyList(), "");
+        issue3.setComponent("impacted-3:1.0.0");
+
+        // Add issues to node1 and node 2
+        node1.setIssues(Sets.newHashSet(issue1));
+        node2.setIssues(Sets.newHashSet(issue1, issue2, issue3));
+    }
+
+    /**
+     * Add some violated licences to node1 and node 2.
+     *
+     * @param node1 - The first node
+     * @param node2 - The second node
+     */
+    private void addViolatedLicenses(DependencyTree node1, DependencyTree node2) {
+        // Create 3 violated licenses
+        License violatedLicense1 = new License("The apache software license version 2.0", "Apache-2.0", Collections.emptyList(), true);
+        violatedLicense1.setComponent("impacted-1:1.0.0");
+        License violatedLicense2 = new License("The MIT License", "MIT", Collections.emptyList(), true);
+        violatedLicense2.setComponent("impacted-2:1.0.0");
+        License violatedLicense3 = new License("Eclipse Public License 1.0", "EPL-1.0", Collections.emptyList(), true);
+        violatedLicense3.setComponent("impacted-3:1.0.0");
+
+        // Add violated licenses to node1 and node 2
+        node1.setViolatedLicenses(Sets.newHashSet(violatedLicense1));
+        node2.setViolatedLicenses(Sets.newHashSet(violatedLicense1, violatedLicense2, violatedLicense3));
+    }
+}

--- a/src/test/java/com/jfrog/ide/common/exporter/ExporterTest.java
+++ b/src/test/java/com/jfrog/ide/common/exporter/ExporterTest.java
@@ -24,13 +24,13 @@ public class ExporterTest {
     private static final File EXPECTED_VIOLATED_LICENSES_CSV = EXPORTER_RESULTS.resolve("violatedLicenses.csv").toFile();
 
     @Test
-    public void testGenerateEmptyIssuesReport() throws Exception {
+    public void testGenerateEmptyVulnerabilitiesReport() throws Exception {
         Exporter exporter = new CsvExporter(new DependencyTree());
         assertEquals("", exporter.generateVulnerabilitiesReport());
     }
 
     @Test
-    public void testGenerateIssuesReport() throws Exception {
+    public void testGenerateVulnerabilitiesReport() throws Exception {
         String expected = FileUtils.readFileToString(EXPECTED_ISSUES_CSV, StandardCharsets.UTF_8);
         Exporter exporter = new CsvExporter(createTestTree());
         assertEquals(exporter.generateVulnerabilitiesReport(), expected);

--- a/src/test/java/com/jfrog/ide/common/filter/Utils.java
+++ b/src/test/java/com/jfrog/ide/common/filter/Utils.java
@@ -19,7 +19,7 @@ public class Utils {
      * @param severity the issue severity
      * @return the random issue
      */
-    static Issue createIssue(Severity severity) {
+    public static Issue createIssue(Severity severity) {
         return new Issue(generateUID(), severity, generateUID(), Lists.newArrayList(), Lists.newArrayList(),
                 Lists.newArrayList(), generateUID());
     }
@@ -31,7 +31,7 @@ public class Utils {
      * @return the license
      */
     static License createLicense(String name) {
-        return new License(new ArrayList<>(), name, name, new ArrayList<>());
+        return new License(name, name, new ArrayList<>());
     }
 
     private static String generateUID() {

--- a/src/test/java/com/jfrog/ide/common/filter/Utils.java
+++ b/src/test/java/com/jfrog/ide/common/filter/Utils.java
@@ -20,7 +20,8 @@ public class Utils {
      * @return the random issue
      */
     static Issue createIssue(Severity severity) {
-        return new Issue(generateUID(), severity, generateUID(), Lists.newArrayList(), generateUID());
+        return new Issue(generateUID(), severity, generateUID(), Lists.newArrayList(), Lists.newArrayList(),
+                Lists.newArrayList(), generateUID());
     }
 
     /**

--- a/src/test/java/com/jfrog/ide/common/scan/ScanLogicTest.java
+++ b/src/test/java/com/jfrog/ide/common/scan/ScanLogicTest.java
@@ -135,7 +135,7 @@ public class ScanLogicTest {
         Issue nettyIssue = artifact.getIssues().stream()
                 .filter(issue -> StringUtils.equals(issue.getIssueId(), "XRAY-89129")).findAny().orElse(null);
         assertNotNull(nettyIssue);
-        assertEquals(nettyIssue.getCve(), "CVE-2019-16869");
+        assertEquals(nettyIssue.getCves().get(0), "CVE-2019-16869");
         assertEquals(nettyIssue.getSummary(), "Netty before 4.1.42.Final mishandles whitespace before the colon in HTTP headers (such as a \"Transfer-Encoding : chunked\" line), which leads to HTTP request smuggling.");
         assertEquals(nettyIssue.getFixedVersions(), Lists.newArrayList("[4.1.44.Final]"));
 

--- a/src/test/java/com/jfrog/ide/common/scan/ScanLogicTest.java
+++ b/src/test/java/com/jfrog/ide/common/scan/ScanLogicTest.java
@@ -135,7 +135,7 @@ public class ScanLogicTest {
         Issue nettyIssue = artifact.getIssues().stream()
                 .filter(issue -> StringUtils.equals(issue.getIssueId(), "XRAY-89129")).findAny().orElse(null);
         assertNotNull(nettyIssue);
-        assertEquals(nettyIssue.getCves().get(0), "CVE-2019-16869");
+        assertEquals(nettyIssue.getCves().get(0).getCveId(), "CVE-2019-16869");
         assertEquals(nettyIssue.getSummary(), "Netty before 4.1.42.Final mishandles whitespace before the colon in HTTP headers (such as a \"Transfer-Encoding : chunked\" line), which leads to HTTP request smuggling.");
         assertEquals(nettyIssue.getFixedVersions(), Lists.newArrayList("[4.1.44.Final]"));
 

--- a/src/test/resources/exporter/issues.csv
+++ b/src/test/resources/exporter/issues.csv
@@ -1,0 +1,4 @@
+"SEVERITY","IMPACTED DEPENDENCY","VERSION","TYPE","FIXED VERSIONS","DIRECT DEPENDENCIES","CVES","CVSS V2","CVSS V3","ISSUE ID","SUMMARY"
+"Critical","impacted-1","1.0.0","Go","2.0.0;3.0.0","node-1:1.0.0;node-2:1.1.0","CVE-1;CVE-11","8.0;","9.0;9.1","XRAY-1","Issue 1 summary"
+"High","impacted-3","1.0.0","Go","4.0.0","node-2:1.1.0","CVE-3","7.0","8.0","XRAY-3","Issue 3 summary"
+"Low","impacted-2","1.0.0","Go","1.0.0","node-2:1.1.0","CVE-2","7.0","8.0","XRAY-2","Issue 2 summary"

--- a/src/test/resources/exporter/violatedLicenses.csv
+++ b/src/test/resources/exporter/violatedLicenses.csv
@@ -1,0 +1,4 @@
+"LICENSE","IMPACTED DEPENDENCY","VERSION","TYPE","DIRECT DEPENDENCIES"
+"Apache-2.0","impacted-1","1.0.0","Go","node-1:1.0.0;node-2:1.1.0"
+"EPL-1.0","impacted-3","1.0.0","Go","node-2:1.1.0"
+"MIT","impacted-2","1.0.0","Go","node-2:1.1.0"


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Depends on https://github.com/jfrog/build-info/pull/611 & https://github.com/jfrog/xray-client-java/pull/31.

* Add CSV exporter
* Store CVEs (plural), references, and ignore URL in the cache.
 