### PR TITLE
Allow scanning npm projects without node_modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        node: [14, 16.9, 16]
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
@@ -23,7 +24,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: ${{ matrix.node }}
           check-latest: true
 
       # Run tests

--- a/src/main/java/com/jfrog/ide/common/npm/NpmTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/npm/NpmTreeBuilder.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.Map;
 
-import static com.jfrog.ide.common.log.Utils.logError;
 import static com.jfrog.ide.common.utils.Utils.createComponentId;
 
 /**
@@ -49,7 +48,7 @@ public class NpmTreeBuilder {
         if (!npmDriver.isNpmInstalled()) {
             throw new IOException("Could not scan npm project dependencies, because npm CLI is not in the PATH.");
         }
-        JsonNode npmLsResults = npmDriver.list(projectDir.toFile(), Lists.newArrayList("--prod"));
+        JsonNode npmLsResults = npmDriver.list(projectDir.toFile(), Lists.newArrayList("--prod", "--package-lock-only"));
         DependencyTree rootNode = buildUnifiedDependencyTree(npmLsResults);
         JsonNode packageJson = objectMapper.readTree(projectDir.resolve("package.json").toFile());
         JsonNode nameNode = packageJson.get("name");
@@ -75,7 +74,7 @@ public class NpmTreeBuilder {
         rootNode.setMetadata(true);
 
         // Run "npm ls" on the development scope
-        npmLsResults = npmDriver.list(projectDir.toFile(), Lists.newArrayList("--dev"));
+        npmLsResults = npmDriver.list(projectDir.toFile(), Lists.newArrayList("--dev", "--package-lock-only"));
         DependencyTree devRootNode = NpmDependencyTree.createDependencyTree(npmLsResults, NpmScope.DEVELOPMENT, projectDir);
 
         // Merge trees. We'll convert to ArrayList to avoid ConcurrentModificationException on the vector.
@@ -139,7 +138,8 @@ public class NpmTreeBuilder {
         String postfix = "";
         if (npmLsResults.get("problems") != null) {
             postfix += " (Not installed)";
-            logError(logger, "JFrog Xray - npm ls command at " + projectDir.toString() + " result had errors:" + "\n" + npmLsResults.get("problems").toString(), shouldToast);
+            logger.warn("Errors occurred during building the Npm dependency tree. " +
+                    "The dependency tree may be incomplete:\n" + npmLsResults.get("problems").toString());
         }
         return postfix;
     }

--- a/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
@@ -3,10 +3,12 @@ package com.jfrog.ide.common.npm;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.client.Version;
 import org.jfrog.build.extractor.npm.NpmDriver;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.GeneralInfo;
 import org.jfrog.build.extractor.scan.Scope;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -49,6 +51,8 @@ public class NpmTreeBuilderTest {
     }
 
     private final NpmDriver npmDriver = new NpmDriver(null);
+    private final boolean isNpm7 = isNpm7();
+    private DependencyTree dependencyTree;
     private File tempProject;
 
     @BeforeMethod
@@ -57,6 +61,13 @@ public class NpmTreeBuilderTest {
             tempProject = Files.createTempDirectory("ide-plugins-common-npm").toFile();
             tempProject.deleteOnExit();
             FileUtils.copyDirectory(((Project) testArgs[0]).path.toFile(), tempProject);
+
+            if ((Boolean) testArgs[1]) {
+                npmDriver.install(tempProject, Lists.newArrayList(), null);
+            }
+            NpmTreeBuilder npmTreeBuilder = new NpmTreeBuilder(tempProject.toPath(), null);
+            dependencyTree = npmTreeBuilder.buildTree(new NullLog(), false);
+            assertNotNull(dependencyTree);
         } catch (IOException e) {
             fail(e.getMessage(), e);
         }
@@ -68,7 +79,7 @@ public class NpmTreeBuilderTest {
     }
 
     @DataProvider
-    private Object[][] npmTreeBuilderProvider() {
+    private Object[][] npm6TreeBuilderProvider() {
         return new Object[][]{
                 {Project.EMPTY, false, 0},
                 {Project.EMPTY, true, 0},
@@ -81,34 +92,58 @@ public class NpmTreeBuilderTest {
         };
     }
 
+    @Test(dataProvider = "npm6TreeBuilderProvider")
+    public void npm6TreeBuilderTest(Project project, boolean install, int expectedChildren) {
+        if (isNpm7()) {
+            throw new SkipException("Skip test on npm >= 7");
+        }
+
+        String expectedProjectName = project.name;
+        if (!install && project.hasChildren) {
+            expectedProjectName += " (Not installed)";
+        }
+        checkDependencyTree(expectedProjectName, expectedChildren);
+    }
+
+    @DataProvider
+    private Object[][] npm7TreeBuilderProvider() {
+        return new Object[][]{
+                {Project.EMPTY, true, 0},
+                {Project.DEPENDENCY, false, 0},
+                {Project.DEPENDENCY, true, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, false, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, true, 2},
+                {Project.DEV_AND_PROD, false, 0},
+                {Project.DEV_AND_PROD, true, 1},
+        };
+    }
+
     @SuppressWarnings("unused")
-    @Test(dataProvider = "npmTreeBuilderProvider")
-    private void npmTreeBuilderTest(Project project, boolean install, int expectedChildren) {
-        try {
-            if (install) {
-                npmDriver.install(tempProject, Lists.newArrayList(), null);
-            }
-            NpmTreeBuilder npmTreeBuilder = new NpmTreeBuilder(tempProject.toPath(), null);
-            DependencyTree dependencyTree = npmTreeBuilder.buildTree(new NullLog(), false);
-            assertNotNull(dependencyTree);
-            String expectedProjectName = project.name;
-            if (!install && project.hasChildren) {
-                expectedProjectName += " (Not installed)";
-            }
-            checkGeneralInfo(dependencyTree.getGeneralInfo(), expectedProjectName, tempProject);
-            assertEquals(dependencyTree.getChildren().size(), expectedChildren);
-            switch (expectedChildren) {
-                case 0:
-                    noChildrenScenario(dependencyTree);
-                    break;
-                case 1:
-                    oneChildScenario(dependencyTree, expectedProjectName);
-                    break;
-                case 2:
-                    twoChildrenScenario(dependencyTree, expectedProjectName);
-            }
-        } catch (IOException e) {
-            fail(e.getMessage(), e);
+    @Test(dataProvider = "npm7TreeBuilderProvider")
+    public void npm7TreeBuilderTest(Project project, boolean install, int expectedChildren) {
+        if (!isNpm7()) {
+            throw new SkipException("Skip test on npm < 7");
+        }
+        String expectedProjectName = project.name;
+        boolean packageLockExist = Files.exists(tempProject.toPath().resolve("package-lock.json"));
+        if (!packageLockExist) {
+            expectedProjectName += " (Not installed)";
+        }
+        checkDependencyTree(expectedProjectName, expectedChildren);
+    }
+
+    private void checkDependencyTree(String expectedProjectName, int expectedChildren) {
+        checkGeneralInfo(dependencyTree.getGeneralInfo(), expectedProjectName, tempProject);
+        assertEquals(dependencyTree.getChildren().size(), expectedChildren);
+        switch (expectedChildren) {
+            case 0:
+                noChildrenScenario(dependencyTree);
+                break;
+            case 1:
+                oneChildScenario(dependencyTree, expectedProjectName);
+                break;
+            case 2:
+                twoChildrenScenario(dependencyTree, expectedProjectName);
         }
     }
 
@@ -128,7 +163,10 @@ public class NpmTreeBuilderTest {
     private void oneChildScenario(DependencyTree dependencyTree, String expectedProjectName) {
         DependencyTree child = dependencyTree.getChildren().get(0);
         assertEquals("progress:2.0.3", child.toString());
-        Set<Scope> expectedScopes = Sets.newHashSet(new Scope("prod"), new Scope("dev"));
+        Set<Scope> expectedScopes = Sets.newHashSet(new Scope("dev"));
+        if (!isNpm7) {
+            expectedScopes.add(new Scope("prod"));
+        }
         assertEquals(child.getScopes(), expectedScopes);
         assertEquals(child.getParent().toString(), expectedProjectName);
     }
@@ -146,6 +184,15 @@ public class NpmTreeBuilderTest {
                     fail("Unexpected dependency " + child);
             }
             assertEquals(child.getParent().toString(), expectedProjectName);
+        }
+    }
+
+    private boolean isNpm7() {
+        try {
+            Version version = new Version(npmDriver.version(new File(".")));
+            return version.isAtLeast(new Version("7.0.0"));
+        } catch (IOException | InterruptedException e) {
+            return false;
         }
     }
 }

--- a/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
@@ -62,6 +62,7 @@ public class NpmTreeBuilderTest {
             tempProject.deleteOnExit();
             FileUtils.copyDirectory(((Project) testArgs[0]).path.toFile(), tempProject);
 
+            // If true, the test require to run "npm install"
             if ((Boolean) testArgs[1]) {
                 npmDriver.install(tempProject, Lists.newArrayList(), null);
             }
@@ -164,6 +165,7 @@ public class NpmTreeBuilderTest {
         DependencyTree child = dependencyTree.getChildren().get(0);
         assertEquals("progress:2.0.3", child.toString());
         Set<Scope> expectedScopes = Sets.newHashSet(new Scope("dev"));
+        // If using npm 6, the dependency may be either in dev and prod scopes
         if (!isNpm7) {
             expectedScopes.add(new Scope("prod"));
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jfrog-idea-plugin/issues/192

npm >= 7 allows running ls with `--package-lock-only` flag:
> If set to true, the current operation will only use the package-lock.json, ignoring node_modules.

https://docs.npmjs.com/cli/v7/commands/npm-ls#package-lock-only

Generally, in npm, unknown flags are skipped. Therefore we can safely use this flag on npm 6, without doing any harm.