### PR TITLE
Running AQL with wrong credentials logs uninformative message

### DIFF
--- a/src/main/java/com/jfrog/ide/common/ci/CiManagerBase.java
+++ b/src/main/java/com/jfrog/ide/common/ci/CiManagerBase.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.search.AqlSearchResult;
 import org.jfrog.build.api.util.Log;
+import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.producerConsumer.ConsumerRunnableBase;
@@ -84,7 +85,7 @@ public class CiManagerBase {
     public void buildCiTree(String buildsPattern, String project, ProgressIndicator indicator, Runnable checkCanceled, boolean shouldToast) throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         root = new DependencyTree();
         XrayClientBuilder xrayClientBuilder = createXrayClientBuilder(serverConfig, log);
-        ArtifactoryManagerBuilder artifactoryManagerBuilder = createArtifactoryManagerBuilder(serverConfig, log);
+        ArtifactoryManagerBuilder artifactoryManagerBuilder = createArtifactoryManagerBuilder(serverConfig, new NullLog());
         try (ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build()) {
             buildsCache.createDirectories();
             String buildInfoRepo = StringUtils.defaultIfBlank(serverConfig.getProject(), DEFAULT_PROJECT) + "-build-info";


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jfrog-idea-plugin/issues/204

An attempt to running a CI scan with wrong credentials logs the following message, followed by a stacktrace:
> Failed to search artifact by the aql 'items.find({"repo":"artifactory-build-info","path":{"$match":"*"}}).include("name","repo","path","created").sort({"$desc":["created"]}).limit(100)'

This message does not help to understand the root cause of the issue, which is - bad credentials.

On the other hand, the exception with the real root cause does being caught and logged.