### PR TITLE
Fix ConcurrentModificationException in cache

### DIFF
--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
@@ -11,6 +11,7 @@ import org.jfrog.build.extractor.scan.Artifact;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.jfrog.ide.common.utils.Utils.createMapper;
@@ -85,7 +86,7 @@ abstract class ScanCacheMap {
                 logger.warn("Incorrect cache version " + scanCacheMap.getVersion() + ". Zapping the old cache and starting a new one.");
                 return;
             }
-            this.artifactsMap = scanCacheMap.artifactsMap;
+            this.artifactsMap = Collections.synchronizedMap(scanCacheMap.artifactsMap);
         } catch (JsonParseException | JsonMappingException e) {
             logger.warn("Failed reading cache file, zapping the old cache and starting a new one.");
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix the following exception:
> com.fasterxml.jackson.databind.JsonMappingException: (was java.util.ConcurrentModificationException) (through reference chain: com.jfrog.ide.common.persistency.XrayScanCacheMap["artifactsMap"])
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:390)
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:349)
    at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:316)
    at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:778)
    at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
    at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4487)
    at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3684)
    at com.jfrog.ide.common.persistency.ScanCacheMap.write(ScanCacheMap.java:78)
    at com.jfrog.ide.common.persistency.ScanCache.write(ScanCache.java:32)