### PR TITLE
when readCommonCache occur error, log exception message

### DIFF
--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
@@ -89,7 +89,7 @@ abstract class ScanCacheMap {
             }
             this.artifactsMap = Collections.synchronizedMap(scanCacheMap.artifactsMap);
         } catch (JsonParseException | JsonMappingException e) {
-            Utils.logError(logger, "Failed reading cache file, zapping the old cache and starting a new one.", e,false);
+            Utils.logError(logger, "Failed reading cache file, zapping the old cache and starting a new one.", e, false);
         }
     }
 }

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheMap.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jfrog.ide.common.log.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import org.jfrog.build.api.util.Log;
@@ -88,7 +89,7 @@ abstract class ScanCacheMap {
             }
             this.artifactsMap = Collections.synchronizedMap(scanCacheMap.artifactsMap);
         } catch (JsonParseException | JsonMappingException e) {
-            logger.warn("Failed reading cache file, zapping the old cache and starting a new one.");
+            Utils.logError(logger, "Failed reading cache file, zapping the old cache and starting a new one.", e,false);
         }
     }
 }


### PR DESCRIPTION
when i use this artifact and build-info-extractor-2.35.0, ScanCacheMap.readCommonCache() will occur error, but i don't know what exception. Later, although I learned that it was a build-info-extractor version problem, I thought that this exception information should not be lost, but should be recorded. 