### PR TITLE
Skip VCS stamping in Go

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.37.4'
+def buildInfoVersion = '2.39.0'
 dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-go', version: buildInfoVersion

--- a/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
@@ -5,11 +5,11 @@ import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.Version;
 import org.jfrog.build.extractor.executor.CommandResults;
 import org.jfrog.build.extractor.go.GoDriver;
+import org.jfrog.build.extractor.go.extractor.GoDependencyTree;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.GeneralInfo;
 import org.jfrog.build.extractor.scan.Scope;
@@ -17,8 +17,8 @@ import org.jfrog.build.extractor.scan.Scope;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by Bar Belity on 06/02/2020.
@@ -26,12 +26,12 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings({"unused"})
 public class GoTreeBuilder {
-
     // Required files of the gomod-absolutizer Go program
     private static final String[] GO_MOD_ABS_COMPONENTS = new String[]{"go.mod", "go.sum", "main.go", "utils.go"};
+    private static final Version MIN_GO_VERSION_FOR_BUILD_VCS_FLAG = new Version("1.18");
     public static final String GO_VERSION_PATTERN = "^go(\\d*.\\d*.*\\d*)";
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final Version MIN_GO_VERSION = new Version("1.16");
+    static final Version MIN_GO_VERSION = new Version("1.16");
     private final Map<String, String> env;
     private final String executablePath;
     private final Path projectDir;
@@ -53,8 +53,9 @@ public class GoTreeBuilder {
             }
 
             CommandResults versionRes = goDriver.version(false);
-            goDriver.modTidy(false, !isBelow16(versionRes, logger));
-            DependencyTree rootNode = createDependencyTree(goDriver);
+            Version goVersion = parseGoVersion(versionRes, logger);
+            goDriver.modTidy(false, goVersion.isAtLeast(MIN_GO_VERSION));
+            DependencyTree rootNode = GoDependencyTree.createDependencyTree(goDriver, logger, false, goVersion.isAtLeast(MIN_GO_VERSION_FOR_BUILD_VCS_FLAG));
             setGeneralInfo(rootNode);
             setNoneScope(rootNode);
             return rootNode;
@@ -69,18 +70,17 @@ public class GoTreeBuilder {
      *
      * @param versionRes - "go version" command results
      * @param logger     - The logger
-     * @return true if the Go version is < 1.16
+     * @return the parsed Go version or fallback to "1.16"
      */
-    static boolean isBelow16(CommandResults versionRes, Log logger) {
+    static Version parseGoVersion(CommandResults versionRes, Log logger) {
         String[] versionSplit = StringUtils.split(versionRes.getRes());
         if (ArrayUtils.getLength(versionSplit) < 4 || !versionSplit[2].matches(GO_VERSION_PATTERN)) {
             logger.info("Couldn't not retrieve Go version from version command results: " + versionRes.getRes() + ". Assuming >= 1.16");
             // This in case of a future Go version that may return a version string different than the expected.
             // This future version is not below 1.16 and therefore we should return false.
-            return false;
+            return MIN_GO_VERSION;
         }
-        Version version = new Version(StringUtils.substringAfter(versionSplit[2], "go"));
-        return !version.isAtLeast(MIN_GO_VERSION);
+        return new Version(StringUtils.substringAfter(versionSplit[2], "go"));
     }
 
     /**
@@ -125,39 +125,6 @@ public class GoTreeBuilder {
         return goModAbsDir;
     }
 
-    private DependencyTree createDependencyTree(GoDriver goDriver) throws IOException {
-        // Run go mod graph.
-        CommandResults goGraphResult = goDriver.modGraph(false);
-        String[] dependenciesGraph = goGraphResult.getRes().split("\\r?\\n");
-
-        // Run go list -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all
-        CommandResults usedModulesResults;
-        try {
-            usedModulesResults = goDriver.getUsedModules(false, false);
-        } catch (IOException e) {
-            // Errors occurred during running "go list". Run again and this time ignore errors.
-            usedModulesResults = goDriver.getUsedModules(false, true);
-            logger.warn("Errors occurred during building the Go dependency tree. The dependency tree may be incomplete:" +
-                    System.lineSeparator() + ExceptionUtils.getRootCauseMessage(e));
-        }
-        Set<String> usedModules = Arrays.stream(usedModulesResults.getRes().split("\\r?\\n"))
-                .map(String::trim)
-                .map(usedModule -> usedModule.replace(" ", "@"))
-                .collect(Collectors.toSet());
-
-        // Create root node.
-        String rootPackageName = goDriver.getModuleName();
-        DependencyTree rootNode = new DependencyTree(rootPackageName);
-        rootNode.setMetadata(true);
-
-        // Build dependency tree.
-        Map<String, List<String>> allDependencies = new HashMap<>();
-        populateAllDependenciesMap(dependenciesGraph, allDependencies, usedModules);
-        populateDependencyTree(rootNode, rootPackageName, allDependencies);
-
-        return rootNode;
-    }
-
     private void setGeneralInfo(DependencyTree rootNode) {
         rootNode.setGeneralInfo(new GeneralInfo()
                 .componentId(rootNode.getUserObject().toString())
@@ -173,36 +140,5 @@ public class GoTreeBuilder {
     private static void setNoneScope(DependencyTree rootNode) {
         Set<Scope> scopes = Sets.newHashSet(new Scope());
         rootNode.getChildren().forEach(child -> child.setScopes(scopes));
-    }
-
-    static void populateAllDependenciesMap(String[] dependenciesGraph, Map<String, List<String>> allDependencies, Set<String> usedModules) {
-        for (String entry : dependenciesGraph) {
-            if (StringUtils.isAllBlank(entry)) {
-                continue;
-            }
-            String[] parsedEntry = entry.split("\\s");
-            if (!usedModules.contains(parsedEntry[1])) {
-                // Module is not in use
-                continue;
-            }
-            List<String> pkgDeps = allDependencies.computeIfAbsent(parsedEntry[0], k -> new ArrayList<>());
-            pkgDeps.add(parsedEntry[1]);
-        }
-    }
-
-    void populateDependencyTree(DependencyTree currNode, String currNameVersionString, Map<String, List<String>> allDependencies) {
-        if (currNode.hasLoop(logger)) {
-            return;
-        }
-        List<String> currDependencies = allDependencies.get(currNameVersionString);
-        if (currDependencies == null) {
-            return;
-        }
-        for (String dependency : currDependencies) {
-            String[] dependencyNameVersion = dependency.split("@v");
-            DependencyTree DependencyTree = new DependencyTree(dependencyNameVersion[0] + ":" + dependencyNameVersion[1]);
-            currNode.add(DependencyTree);
-            populateDependencyTree(DependencyTree, dependency, allDependencies);
-        }
     }
 }

--- a/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/go/GoTreeBuilderTest.java
@@ -1,6 +1,5 @@
 package com.jfrog.ide.common.go;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.api.util.NullLog;
@@ -13,9 +12,12 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
 
-import static com.jfrog.ide.common.go.GoTreeBuilder.isBelow16;
+import static com.jfrog.ide.common.go.GoTreeBuilder.MIN_GO_VERSION;
+import static com.jfrog.ide.common.go.GoTreeBuilder.parseGoVersion;
 import static org.testng.Assert.*;
 
 /**
@@ -39,7 +41,7 @@ public class GoTreeBuilderTest {
         try {
             GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project1"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
-            validateDependencyTreeResults(expected, dt, true);
+            validateDependencyTreeResults(expected, dt);
         } catch (IOException ex) {
             fail(ExceptionUtils.getStackTrace(ex));
         }
@@ -56,7 +58,7 @@ public class GoTreeBuilderTest {
         try {
             GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project2"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
-            validateDependencyTreeResults(expected, dt, true);
+            validateDependencyTreeResults(expected, dt);
         } catch (IOException ex) {
             fail(ExceptionUtils.getStackTrace(ex));
         }
@@ -74,7 +76,7 @@ public class GoTreeBuilderTest {
         try {
             GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project3"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
-            validateDependencyTreeResults(expected, dt, true);
+            validateDependencyTreeResults(expected, dt);
         } catch (IOException ex) {
             fail(ExceptionUtils.getStackTrace(ex));
         }
@@ -92,80 +94,19 @@ public class GoTreeBuilderTest {
         try {
             GoTreeBuilder treeBuilder = new GoTreeBuilder(null, GO_ROOT.resolve("project4"), null, log);
             DependencyTree dt = treeBuilder.buildTree();
-            validateDependencyTreeResults(expected, dt, true);
+            validateDependencyTreeResults(expected, dt);
         } catch (IOException ex) {
             fail(ExceptionUtils.getStackTrace(ex));
         }
     }
 
-    private Map<String, List<String>> getAllDependenciesForTest() {
-        return new HashMap<>() {{
-            put("my/pkg/name1", Arrays.asList(
-                    "github.com/jfrog/directDep1@v0.1",
-                    "github.com/jfrog/directDep2@v0.2",
-                    "github.com/jfrog/directDep3@v0.3"));
-            put("github.com/jfrog/directDep1@v0.1", List.of(
-                    "github.com/jfrog/indirectDep1-1@v1.1",
-                    "github.com/jfrog/indirectDep2-1@v1.3"));
-            put("github.com/jfrog/directDep2@v0.2", Collections.singletonList(
-                    "github.com/jfrog/indirectDep1-2@v2.1"));
-            put("github.com/jfrog/indirectDep1-1@v1.1", Collections.singletonList(
-                    "github.com/jfrog/indirectIndirectDep1-1-1@v1.1.1"));
-        }};
-    }
-
-    @Test
-    public void testPopulateAllDependenciesMap() {
-        // Output of 'go mod graph'.
-        String[] dependenciesGraph = new String[]{
-                "my/pkg/name1 github.com/jfrog/directDep1@v0.1",
-                "my/pkg/name1 github.com/jfrog/directDep2@v0.2",
-                "my/pkg/name1 github.com/jfrog/directDep3@v0.3",
-                "github.com/jfrog/directDep1@v0.1 github.com/jfrog/indirectDep1-1@v1.1",
-                // github.com/jfrog/indirectDep2-1@v1.2 does not appear in the used modules set:
-                "github.com/jfrog/directDep1@v0.1 github.com/jfrog/indirectDep2-1@v1.2",
-                "github.com/jfrog/directDep1@v0.1 github.com/jfrog/indirectDep2-1@v1.3",
-                "github.com/jfrog/directDep2@v0.2 github.com/jfrog/indirectDep1-2@v2.1",
-                "github.com/jfrog/indirectDep1-1@v1.1 github.com/jfrog/indirectIndirectDep1-1-1@v1.1.1"
-        };
-        Set<String> usedModules = Sets.newHashSet("github.com/jfrog/directDep1@v0.1",
-                "github.com/jfrog/directDep2@v0.2",
-                "github.com/jfrog/directDep3@v0.3",
-                "github.com/jfrog/indirectDep1-1@v1.1",
-                "github.com/jfrog/indirectDep2-1@v1.3",
-                "github.com/jfrog/indirectDep1-2@v2.1",
-                "github.com/jfrog/indirectIndirectDep1-1-1@v1.1.1");
-        // Run method.
-        Map<String, List<String>> expectedAllDependencies = getAllDependenciesForTest();
-        Map<String, List<String>> actualAllDependencies = new HashMap<>();
-        GoTreeBuilder.populateAllDependenciesMap(dependenciesGraph, actualAllDependencies, usedModules);
-        // Validate result.
-        assertEquals(expectedAllDependencies, actualAllDependencies);
-    }
-
-    @Test
-    public void testPopulateDependencyTree() {
-        Map<String, Integer> expected = new HashMap<>() {{
-            put("github.com/jfrog/directDep1:0.1", 2);
-            put("github.com/jfrog/directDep2:0.2", 1);
-            put("github.com/jfrog/directDep3:0.3", 0);
-        }};
-        Map<String, List<String>> allDependencies = getAllDependenciesForTest();
-        DependencyTree rootNode = new DependencyTree();
-        GoTreeBuilder treeBuilder = new GoTreeBuilder(null, Paths.get(""), null, log);
-        treeBuilder.populateDependencyTree(rootNode, "my/pkg/name1", allDependencies);
-        validateDependencyTreeResults(expected, rootNode, false);
-    }
-
-    private void validateDependencyTreeResults(Map<String, Integer> expected, DependencyTree actual, boolean checkScope) {
+    private void validateDependencyTreeResults(Map<String, Integer> expected, DependencyTree actual) {
         Vector<DependencyTree> children = actual.getChildren();
         assertEquals(children.size(), expected.size());
         for (DependencyTree current : children) {
             assertTrue(expected.containsKey(current.toString()));
             assertEquals(current.getChildren().size(), expected.get(current.toString()).intValue());
-            if (checkScope) {
-                assertTrue(current.getScopes().contains(NONE_SCOPE));
-            }
+            assertTrue(current.getScopes().contains(NONE_SCOPE));
         }
     }
 
@@ -173,27 +114,22 @@ public class GoTreeBuilderTest {
     private Object[][] goVersionProvider() {
         return new Object[][]{
                 // Below 1.16
-                {"go version go1.9 darwin/amd64", true},
-                {"go version go1.15 darwin/amd64", true},
-                {"go version go1.15.4 darwin/amd64", true},
-
-                // Above 1.16
-                {"go version go1.16 darwin/amd64", false},
-                {"go version go1.16.1 darwin/amd64", false},
-                {"go version go1.17.7 darwin/amd64", false},
+                {"go version go1.9 darwin/amd64", "1.9"},
+                {"go version go1.15 darwin/amd64", "1.15"},
+                {"go version go1.15.4 darwin/amd64", "1.15.4"},
 
                 // Error values
-                {"go version 1.15 darwin/amd64", false},
-                {"go version 1.17 darwin/amd64", false},
-                {"1.17", false},
-                {"1.15", false},
+                {"go version 1.15 darwin/amd64", MIN_GO_VERSION.toString()},
+                {"go version 1.17 darwin/amd64", MIN_GO_VERSION.toString()},
+                {"1.17", MIN_GO_VERSION.toString()},
+                {"1.15", MIN_GO_VERSION.toString()},
         };
     }
 
     @Test(dataProvider = "goVersionProvider")
-    public void testIsBelow16(String versionOutput, boolean expectedBelow) {
+    public void testParseGoVersion(String versionOutput, String expectedVersion) {
         CommandResults commandResults = new CommandResults();
         commandResults.setRes(versionOutput);
-        assertEquals(expectedBelow, isBelow16(commandResults, new NullLog()));
+        assertEquals(expectedVersion, parseGoVersion(commandResults, new NullLog()).toString());
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Depends on: https://github.com/jfrog/build-info/pull/689

* Allow providing the dontBuildVcs flag, which can be used to skip VCS stamping to bypass the following error:
> IOException: error obtaining VCS status: exit status 128 Use -buildvcs=false to disable VCS stamping. error obtaining VCS status: exit status 128 Use -buildvcs=false to disable VCS stamping.
* Remove code duplication in Go tree building