### PR TITLE
V1: Skip loading cache from file system in full scan mode

### DIFF
--- a/src/main/java/com/jfrog/ide/common/persistency/XrayScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/XrayScanCache.java
@@ -19,11 +19,11 @@ public class XrayScanCache extends ScanCache {
      *
      * @param projectName - The IDE project name. If this is an npm project, it is a full path to the directory containing the package.json.
      * @param basePath    - The directory for the cache.
-     * @param quickScan   - Set to true to read cache from the file-system, if exist.
+     * @param loadFromFs  - Set to true to read cache from the file-system, if exist.
      * @param logger      - The logger.
      * @throws IOException in case of I/O problem in the paths.
      */
-    public XrayScanCache(String projectName, Path basePath, boolean quickScan, Log logger) throws IOException {
+    public XrayScanCache(String projectName, Path basePath, boolean loadFromFs, Log logger) throws IOException {
         scanCacheMap = new XrayScanCacheMap();
         file = basePath.resolve(Base64.getEncoder().encodeToString(projectName.getBytes(StandardCharsets.UTF_8)) + "XrayScanCache.json").toFile();
         logger.debug("Project cache path: " + file.getAbsolutePath());
@@ -31,7 +31,7 @@ public class XrayScanCache extends ScanCache {
             Files.createDirectories(basePath);
             return;
         }
-        if (quickScan) {
+        if (loadFromFs) {
             scanCacheMap.read(file, logger);
         }
     }

--- a/src/main/java/com/jfrog/ide/common/persistency/XrayScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/XrayScanCache.java
@@ -19,10 +19,11 @@ public class XrayScanCache extends ScanCache {
      *
      * @param projectName - The IDE project name. If this is an npm project, it is a full path to the directory containing the package.json.
      * @param basePath    - The directory for the cache.
+     * @param quickScan   - Set to true to read cache from the file-system, if exist.
      * @param logger      - The logger.
      * @throws IOException in case of I/O problem in the paths.
      */
-    public XrayScanCache(String projectName, Path basePath, Log logger) throws IOException {
+    public XrayScanCache(String projectName, Path basePath, boolean quickScan, Log logger) throws IOException {
         scanCacheMap = new XrayScanCacheMap();
         file = basePath.resolve(Base64.getEncoder().encodeToString(projectName.getBytes(StandardCharsets.UTF_8)) + "XrayScanCache.json").toFile();
         logger.debug("Project cache path: " + file.getAbsolutePath());
@@ -30,6 +31,8 @@ public class XrayScanCache extends ScanCache {
             Files.createDirectories(basePath);
             return;
         }
-        scanCacheMap.read(file, logger);
+        if (quickScan) {
+            scanCacheMap.read(file, logger);
+        }
     }
 }

--- a/src/main/java/com/jfrog/ide/common/scan/ScanLogic.java
+++ b/src/main/java/com/jfrog/ide/common/scan/ScanLogic.java
@@ -2,7 +2,6 @@ package com.jfrog.ide.common.scan;
 
 import com.jfrog.ide.common.configuration.ServerConfig;
 import com.jfrog.ide.common.log.ProgressIndicator;
-import com.jfrog.ide.common.persistency.ScanCache;
 import org.jfrog.build.extractor.scan.Artifact;
 import org.jfrog.build.extractor.scan.DependencyTree;
 
@@ -12,12 +11,13 @@ public interface ScanLogic {
     /**
      * Scan and cache components.
      *
-     * @param server    - JFrog platform server configuration.
-     * @param indicator - Progress bar.
-     * @param quickScan - Quick or full scan.
+     * @param server        - JFrog platform server configuration.
+     * @param indicator     - Progress bar.
+     * @param prefix        - Components prefix for xray scan, e.g. gav:// or npm://
+     * @param checkCanceled - Callback that throws an exception if scan was cancelled by user
      * @return true if the scan completed successfully, false otherwise.
      */
-    boolean scanAndCacheArtifacts(ServerConfig server, ProgressIndicator indicator, boolean quickScan, ComponentPrefix prefix, Runnable checkCanceled) throws IOException, InterruptedException;
+    boolean scanAndCacheArtifacts(ServerConfig server, ProgressIndicator indicator, ComponentPrefix prefix, Runnable checkCanceled) throws IOException, InterruptedException;
 
     /**
      * @param componentId artifact component ID.
@@ -31,7 +31,5 @@ public interface ScanLogic {
     DependencyTree getScanResults();
 
     void setScanResults(DependencyTree results);
-
-    void setScanCache(ScanCache cache);
 }
 

--- a/src/main/java/com/jfrog/ide/common/scan/ScanManagerBase.java
+++ b/src/main/java/com/jfrog/ide/common/scan/ScanManagerBase.java
@@ -105,11 +105,10 @@ public abstract class ScanManagerBase {
      * Scan and cache components.
      *
      * @param indicator - Progress bar.
-     * @param quickScan - Quick or full scan.
      */
-    public void scanAndCacheArtifacts(ProgressIndicator indicator, boolean quickScan) throws IOException, InterruptedException {
+    public void scanAndCacheArtifacts(ProgressIndicator indicator) throws IOException, InterruptedException {
         log.debug("Start scan for '" + projectName + "'.");
-        if (scanLogic.scanAndCacheArtifacts(serverConfig, indicator, quickScan, prefix, this::checkCanceled)) {
+        if (scanLogic.scanAndCacheArtifacts(serverConfig, indicator, prefix, this::checkCanceled)) {
             log.debug("Scan for '" + projectName + "' finished successfully.");
         } else {
             log.debug("Wasn't able to scan '" + projectName + "'.");

--- a/src/test/java/com/jfrog/ide/common/persistency/ScanCacheTest.java
+++ b/src/test/java/com/jfrog/ide/common/persistency/ScanCacheTest.java
@@ -44,7 +44,7 @@ public class ScanCacheTest {
     public void testGetScanCacheEmpty() {
         String projectName = "not_exits";
         try {
-            ScanCache scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            ScanCache scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             assertNotNull(scanCache);
             assertNull(scanCache.get("not_exits"));
         } catch (IOException e) {
@@ -57,7 +57,7 @@ public class ScanCacheTest {
         String projectName = "Goliath";
         String artifactId = "ant:tony:1.2.3";
         try {
-            ScanCache scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            ScanCache scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             assertNotNull(scanCache);
 
             Artifact artifact = createArtifact(artifactId);
@@ -73,13 +73,13 @@ public class ScanCacheTest {
         String projectName = "Pegasus";
         String artifactId = "red:skull:3.3.3";
         try {
-            ScanCache scanCache1 = new XrayScanCache(projectName, tempDir, new NullLog());
+            ScanCache scanCache1 = new XrayScanCache(projectName, tempDir, true, new NullLog());
             Artifact artifact = createArtifact(artifactId);
 
             scanCache1.add(artifact);
             scanCache1.write();
 
-            ScanCache scanCache2 = new XrayScanCache(projectName, tempDir, new NullLog());
+            ScanCache scanCache2 = new XrayScanCache(projectName, tempDir, true, new NullLog());
             assertEquals(scanCache2.get(artifactId).getGeneralInfo().getComponentId(), artifactId);
         } catch (IOException e) {
             Assert.fail(e.getMessage());
@@ -91,7 +91,7 @@ public class ScanCacheTest {
         String projectName = "Exodus";
         String artifactId = "tony:stark:3.3.3";
         try {
-            ScanCache scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            ScanCache scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             Artifact artifact = createArtifact(artifactId);
 
             scanCache.add(artifact);
@@ -100,7 +100,7 @@ public class ScanCacheTest {
             assertEquals(scanCache.get(artifactId).getGeneralInfo().getComponentId(), artifactId);
 
             // Read again
-            scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             assertEquals(scanCache.get(artifactId).getGeneralInfo().getComponentId(), artifactId);
         } catch (IOException e) {
             Assert.fail(e.getMessage());
@@ -128,20 +128,20 @@ public class ScanCacheTest {
             scanCacheMap.setArtifactsMap(artifactsMap);
 
             // Create ScanCache and flush
-            ScanCache scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            ScanCache scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             scanCache.setScanCacheMap(scanCacheMap);
             scanCache.write();
             assertEquals(scanCache.getScanCacheMap().getVersion(), -1);
             assertEquals(scanCache.getScanCacheMap().getArtifactsMap().get(artifactId), scanCacheObject);
 
             // Read from disk and expect no errors - But empty cache
-            scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             assertEquals(scanCache.getScanCacheMap().getVersion(), CACHE_VERSION);
             assertTrue(scanCache.getScanCacheMap().getArtifactsMap().isEmpty());
 
             // Write and check again
             scanCache.write();
-            scanCache = new XrayScanCache(projectName, tempDir, new NullLog());
+            scanCache = new XrayScanCache(projectName, tempDir, true, new NullLog());
             assertEquals(scanCache.getScanCacheMap().getVersion(), CACHE_VERSION);
             assertTrue(scanCache.getScanCacheMap().getArtifactsMap().isEmpty());
         } catch (IOException e) {

--- a/src/test/java/com/jfrog/ide/common/scan/ScanLogicTest.java
+++ b/src/test/java/com/jfrog/ide/common/scan/ScanLogicTest.java
@@ -73,7 +73,7 @@ public class ScanLogicTest {
     public void setUp() throws IOException {
         mocks = MockitoAnnotations.openMocks(this);
         baseDir = Files.createTempDirectory("ScanLogicTest");
-        scanCache = new XrayScanCache("ScanLogicTest", baseDir, new NullLog());
+        scanCache = new XrayScanCache("ScanLogicTest", baseDir, false, new NullLog());
         scanResults.setMetadata(true);
         scanResults.add(new DependencyTree("gav://io.netty:netty-codec-http:4.1.31.Final"));
         scanResults.add(new DependencyTree("gav://org.apache.commons:commons-lang3:3.12.0"));
@@ -114,7 +114,7 @@ public class ScanLogicTest {
             utilities.when(() -> XrayConnectionUtils.createXrayClientBuilder(serverConfig, log)).thenReturn(new DummyXrayClientBuilder(xrayClient));
             when(xrayClient.system()).thenReturn(new SystemMock(xrayClient));
             scanLogic.setScanResults(scanResults);
-            scanLogic.scanAndCacheArtifacts(serverConfig, progressIndicator, false, ComponentPrefix.GAV, checkCanceled);
+            scanLogic.scanAndCacheArtifacts(serverConfig, progressIndicator, ComponentPrefix.GAV, checkCanceled);
             checkNettyCodec(violations);
             checkCommonsLang(violations);
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jfrog-idea-plugin/issues/248

When changing watches, the cache does not get updated.
This PR changes the way we initialize the scan cache in case of a full scan, by avoiding reading the cache from the file system.