### PR TITLE
Cache last scan results

### DIFF
--- a/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
@@ -3,16 +3,21 @@ package com.jfrog.ide.common.nodes;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 
 public class ApplicableIssueNode extends IssueNode implements SubtitledTreeNode {
-    private final String name;
-    private final String reason;
-    private final String lineSnippet;
-    private final String scannerSearchTarget;
-    private final int rowStart;
-    private final int colStart;
-    private final int rowEnd;
-    private final int colEnd;
-    private final String filePath;
-    private final VulnerabilityNode issue;
+    private String name;
+    private String reason;
+    private String lineSnippet;
+    private String scannerSearchTarget;
+    private int rowStart;
+    private int colStart;
+    private int rowEnd;
+    private int colEnd;
+    private String filePath;
+    private VulnerabilityNode issue;
+
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    private ApplicableIssueNode() {
+    }
 
     public ApplicableIssueNode(String name, int rowStart, int colStart, int rowEnd, int colEnd, String filePath, String reason, String lineSnippet, String scannerSearchTarget, VulnerabilityNode issue) {
         this.name = name;

--- a/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.common.nodes;
 
+import com.jfrog.ide.common.nodes.subentities.ImpactTreeNode;
 import com.jfrog.ide.common.nodes.subentities.License;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/jfrog/ide/common/nodes/DescriptorFileTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DescriptorFileTreeNode.java
@@ -6,6 +6,11 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class DescriptorFileTreeNode extends FileTreeNode {
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    private DescriptorFileTreeNode() {
+    }
+
     public DescriptorFileTreeNode(String filePath) {
         super(filePath);
     }

--- a/src/main/java/com/jfrog/ide/common/nodes/FileTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/FileTreeNode.java
@@ -5,9 +5,13 @@ import com.jfrog.ide.common.nodes.subentities.Severity;
 import java.io.File;
 
 public class FileTreeNode extends SortableChildrenTreeNode implements SubtitledTreeNode, Comparable<FileTreeNode> {
-    protected String fileName;
-    protected String filePath;
+    protected String fileName = "";
+    protected String filePath = "";
     protected Severity topSeverity = Severity.Normal;
+
+    // Empty constructor for deserialization
+    protected FileTreeNode() {
+    }
 
     public FileTreeNode(String filePath) {
         this.filePath = filePath;

--- a/src/main/java/com/jfrog/ide/common/nodes/IssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/IssueNode.java
@@ -1,11 +1,23 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
+import java.util.UUID;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+        getterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "uuid")
 public abstract class IssueNode extends DefaultMutableTreeNode implements SubtitledTreeNode, Comparable<IssueNode> {
+    // For deserialization
+    @SuppressWarnings("unused")
+    private String uuid = UUID.randomUUID().toString();
+
     public abstract Severity getSeverity();
 
     public String getIcon() {

--- a/src/main/java/com/jfrog/ide/common/nodes/IssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/IssueNode.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public abstract class IssueNode extends DefaultMutableTreeNode implements SubtitledTreeNode, Comparable<IssueNode> {
     // For deserialization
     @SuppressWarnings("unused")
-    private String uuid = UUID.randomUUID().toString();
+    private final String uuid = UUID.randomUUID().toString();
 
     public abstract Severity getSeverity();
 

--- a/src/main/java/com/jfrog/ide/common/nodes/LicenseViolationNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/LicenseViolationNode.java
@@ -1,6 +1,5 @@
 package com.jfrog.ide.common.nodes;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 import org.apache.commons.lang3.StringUtils;
 
@@ -22,8 +21,9 @@ public class LicenseViolationNode extends IssueNode {
     private String lastUpdated;
     private List<String> watchNames;
 
+    // Empty constructor for deserialization
     @SuppressWarnings("unused")
-    public LicenseViolationNode() {
+    private LicenseViolationNode() {
         this.fullName = UNKNOWN_LICENCE_FULL_NAME;
         this.name = UNKNOWN_LICENCE_NAME;
     }
@@ -59,7 +59,6 @@ public class LicenseViolationNode extends IssueNode {
         return watchNames;
     }
 
-    @JsonIgnore
     @SuppressWarnings("unused")
     public boolean isFullNameEmpty() {
         return StringUtils.isBlank(fullName) || fullName.equals(LicenseViolationNode.UNKNOWN_LICENCE_FULL_NAME);

--- a/src/main/java/com/jfrog/ide/common/nodes/SortableChildrenTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/SortableChildrenTreeNode.java
@@ -1,11 +1,25 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.apache.commons.collections.CollectionUtils;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.util.Comparator;
+import java.util.UUID;
+import java.util.Vector;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+        getterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "uuid")
 public class SortableChildrenTreeNode extends DefaultMutableTreeNode {
+    // For deserialization
+    @SuppressWarnings("unused")
+    private String uuid = UUID.randomUUID().toString();
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void sortChildren() {
         if (CollectionUtils.isNotEmpty(children)) {
@@ -13,6 +27,16 @@ public class SortableChildrenTreeNode extends DefaultMutableTreeNode {
             children.stream()
                     .filter(treeNode -> treeNode instanceof SortableChildrenTreeNode)
                     .forEach(treeNode -> ((SortableChildrenTreeNode) treeNode).sortChildren());
+        }
+    }
+
+    @JsonSetter("children")
+    private void setChildren(Vector<DefaultMutableTreeNode> children) {
+        if (children == null) {
+            return;
+        }
+        for (DefaultMutableTreeNode child : children) {
+            add(child);
         }
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/VulnerabilityNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/VulnerabilityNode.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.jfrog.ide.common.nodes.subentities.Cve;
 import com.jfrog.ide.common.nodes.subentities.ResearchInfo;
 import com.jfrog.ide.common.nodes.subentities.Severity;
@@ -26,10 +27,13 @@ public class VulnerabilityNode extends IssueNode {
     private String lastUpdated;
     private List<String> watchNames;
     private ResearchInfo researchInfo;
+
+    @JsonIdentityReference(alwaysAsId = true)
     private List<ApplicableIssueNode> applicableIssues;
 
+    // Empty constructor for deserialization
     @SuppressWarnings("unused")
-    public VulnerabilityNode() {
+    private VulnerabilityNode() {
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactTreeNode.java
@@ -1,4 +1,4 @@
-package com.jfrog.ide.common.nodes;
+package com.jfrog.ide.common.nodes.subentities;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -8,6 +8,11 @@ import static com.jfrog.ide.common.utils.Utils.removeComponentIdPrefix;
 public class ImpactTreeNode {
     String name;
     List<ImpactTreeNode> children = new ArrayList<>();
+
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    private ImpactTreeNode() {
+    }
 
     public ImpactTreeNode(String name) {
         this.name = name;

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/License.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/License.java
@@ -1,8 +1,13 @@
 package com.jfrog.ide.common.nodes.subentities;
 
 public class License {
-    private final String name;
-    private final String moreInfoUrl;
+    private String name;
+    private String moreInfoUrl;
+
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    private License() {
+    }
 
     public License(String name, String moreInfoUrl) {
         this.name = name;

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ResearchInfo.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ResearchInfo.java
@@ -1,13 +1,20 @@
 package com.jfrog.ide.common.nodes.subentities;
 
-public class ResearchInfo {
-    private final Severity severity;
-    private final String shortDescription;
-    private final String fullDescription;
-    private final String remediation;
-    private final SeverityReason[] severityReasons;
+import java.util.List;
 
-    public ResearchInfo(Severity severity, String shortDescription, String fullDescription, String remediation, SeverityReason[] severityReasons) {
+public class ResearchInfo {
+    private Severity severity;
+    private String shortDescription;
+    private String fullDescription;
+    private String remediation;
+    private List<SeverityReason> severityReasons;
+
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    private ResearchInfo() {
+    }
+
+    public ResearchInfo(Severity severity, String shortDescription, String fullDescription, String remediation, List<SeverityReason> severityReasons) {
         this.severity = severity;
         this.shortDescription = shortDescription;
         this.fullDescription = fullDescription;
@@ -36,7 +43,7 @@ public class ResearchInfo {
     }
 
     @SuppressWarnings("unused")
-    public SeverityReason[] getSeverityReasons() {
+    public List<SeverityReason> getSeverityReasons() {
         return severityReasons;
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/SeverityReason.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/SeverityReason.java
@@ -1,9 +1,14 @@
 package com.jfrog.ide.common.nodes.subentities;
 
 public class SeverityReason {
-    private final String name;
-    private final String description;
-    private final boolean isPositive;
+    private String name;
+    private String description;
+    private boolean isPositive;
+
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    private SeverityReason() {
+    }
 
     public SeverityReason(String name, String description, boolean isPositive) {
         this.name = name;

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -26,7 +26,7 @@ import static com.jfrog.ide.common.utils.Utils.createMapper;
  */
 public class ScanCache {
     private final File file;
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
     private ScanCacheObject scanCacheObject;
 
     /**

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -1,0 +1,85 @@
+package com.jfrog.ide.common.persistency;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.jfrog.ide.common.log.Utils;
+import com.jfrog.ide.common.nodes.FileTreeNode;
+import org.jfrog.build.api.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+
+import static com.jfrog.ide.common.utils.Utils.createMapper;
+
+/**
+ * Cache for Xray scan results.
+ *
+ * @author yahavi
+ */
+public class ScanCache {
+    private final File file;
+    private ObjectMapper objectMapper;
+    private ScanCacheObject scanCacheObject;
+
+    /**
+     * Construct a scan cache.
+     *
+     * @param projectId - A unique string of a project. This is used to locate and read the cache later.
+     * @param basePath  - The directory for the cache.
+     * @param logger    - The logger.
+     * @throws IOException in case of I/O problem in the paths.
+     */
+    public ScanCache(String projectId, Path basePath, Log logger) throws IOException {
+        // We do that to allow inheritance on deserialization
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.jfrog.ide.common.nodes")
+                .allowIfSubType("com.jfrog.ide.common.nodes.subentities")
+                .allowIfSubType("com.jfrog.ide.common.persistency")
+                .allowIfSubType("java.util.ArrayList")
+                .allowIfSubType("java.util.Vector")
+                .build();
+        objectMapper = createMapper();
+        objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+        file = basePath.resolve(Base64.getEncoder().encodeToString(projectId.getBytes(StandardCharsets.UTF_8)) + "XrayScanCache.json").toFile();
+        logger.debug("Project cache path: " + file.getAbsolutePath());
+        if (!file.exists()) {
+            Files.createDirectories(basePath);
+            return;
+        }
+        readCachedNodes(logger);
+    }
+
+    /**
+     * Write the given {@link FileTreeNode}s to cache.
+     *
+     * @param nodes a list of {@link FileTreeNode}s to cache.
+     * @throws IOException in case of I/O error during write.
+     */
+    public void cacheNodes(List<FileTreeNode> nodes) throws IOException {
+        scanCacheObject = new ScanCacheObject(nodes, System.currentTimeMillis());
+        objectMapper.writeValue(file, scanCacheObject);
+    }
+
+    public ScanCacheObject getScanCacheObject() {
+        return scanCacheObject;
+    }
+
+    private void readCachedNodes(Log logger) throws IOException {
+        try {
+            scanCacheObject = objectMapper.readValue(file, ScanCacheObject.class);
+            if (scanCacheObject.getVersion() != ScanCacheObject.CACHE_VERSION) {
+                logger.warn("Invalid cache version " + scanCacheObject.getVersion() + ". Ignoring the old cache and starting a new one.");
+            }
+        } catch (JsonParseException | JsonMappingException e) {
+            Utils.logError(logger, "Failed reading cache file. Ignoring the old cache and starting a new one.", e, false);
+        }
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheObject.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheObject.java
@@ -19,16 +19,16 @@ public class ScanCacheObject {
 
     @JsonProperty("fileTreeNodes")
     List<FileTreeNode> fileTreeNodes;
-    @JsonProperty("scanTime")
-    long scanTime;
+    @JsonProperty("scanTimestamp")
+    long scanTimestamp;
 
     // Empty constructor for deserialization
     @SuppressWarnings("unused")
     public ScanCacheObject() {
     }
 
-    public ScanCacheObject(List<FileTreeNode> fileTreeNodes, long scanTime) {
+    public ScanCacheObject(List<FileTreeNode> fileTreeNodes, long scanTimestamp) {
         this.fileTreeNodes = fileTreeNodes;
-        this.scanTime = scanTime;
+        this.scanTimestamp = scanTimestamp;
     }
 }

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCacheObject.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCacheObject.java
@@ -1,0 +1,34 @@
+package com.jfrog.ide.common.persistency;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jfrog.ide.common.nodes.FileTreeNode;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * The implementation of the scan cache. Contains a version and a map.
+ * In case of incorrect version, it zaps the cache and starts over a new map.
+ */
+@Getter
+public class ScanCacheObject {
+    static int CACHE_VERSION = 4;
+
+    @JsonProperty("version")
+    int version = CACHE_VERSION;
+
+    @JsonProperty("fileTreeNodes")
+    List<FileTreeNode> fileTreeNodes;
+    @JsonProperty("scanTime")
+    long scanTime;
+
+    // Empty constructor for deserialization
+    @SuppressWarnings("unused")
+    public ScanCacheObject() {
+    }
+
+    public ScanCacheObject(List<FileTreeNode> fileTreeNodes, long scanTime) {
+        this.fileTreeNodes = fileTreeNodes;
+        this.scanTime = scanTime;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/scan/GraphScanLogic.java
+++ b/src/main/java/com/jfrog/ide/common/scan/GraphScanLogic.java
@@ -23,6 +23,7 @@ import org.jfrog.build.extractor.scan.DependencyTree;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CancellationException;
+import java.util.stream.Collectors;
 
 import static com.jfrog.ide.common.utils.XrayConnectionUtils.createXrayClientBuilder;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
@@ -269,14 +270,14 @@ public class GraphScanLogic implements ScanLogic {
         return results.get(componentId);
     }
 
-    private SeverityReason[] convertSeverityReasons(com.jfrog.xray.client.services.scan.SeverityReasons[] xraySeverityReasons) {
+    private List<SeverityReason> convertSeverityReasons(com.jfrog.xray.client.services.scan.SeverityReasons[] xraySeverityReasons) {
         if (xraySeverityReasons == null) {
             return null;
         }
         return Arrays.stream(xraySeverityReasons)
                 .map(xrSeverityReason ->
                         new SeverityReason(xrSeverityReason.getName(), xrSeverityReason.getDescription(), xrSeverityReason.isPositive())
-                ).toArray(SeverityReason[]::new);
+                ).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Save last scan results in cache and show them on plugin startup.