### PR TITLE
Fix writing private and protected fields to cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation(group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13') {
         exclude group: 'commons-codec', module: 'commons-codec'
     }
-    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.134632-1'
+    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.14'

--- a/src/main/java/com/jfrog/ide/common/ci/XrayBuildDetailsDownloader.java
+++ b/src/main/java/com/jfrog/ide/common/ci/XrayBuildDetailsDownloader.java
@@ -101,7 +101,7 @@ public class XrayBuildDetailsDownloader extends ConsumerRunnableBase {
 
     private void downloadBuildDetails(ObjectMapper mapper, XrayClient xrayClient, String buildName, String buildNumber) throws IOException {
         DetailsResponse response = xrayClient.details().build(buildName, buildNumber, project);
-        if (!response.getScanCompleted() || response.getError() != null || isEmpty(response.getComponents())) {
+        if (!response.isScanCompleted() || response.getError() != null || isEmpty(response.getComponents())) {
             if (response.getError() != null) {
                 Error error = response.getError();
                 log.debug(String.format(BUILD_RET_ERR_FMT, buildName, buildNumber) + " " +

--- a/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
@@ -1,17 +1,28 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 
 public class ApplicableIssueNode extends IssueNode implements SubtitledTreeNode {
+    @JsonProperty()
     private String name;
+    @JsonProperty()
     private String reason;
+    @JsonProperty()
     private String lineSnippet;
+    @JsonProperty()
     private String scannerSearchTarget;
+    @JsonProperty()
     private int rowStart;
+    @JsonProperty()
     private int colStart;
+    @JsonProperty()
     private int rowEnd;
+    @JsonProperty()
     private int colEnd;
+    @JsonProperty()
     private String filePath;
+    @JsonProperty()
     private VulnerabilityNode issue;
 
     // Empty constructor for deserialization

--- a/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
@@ -1,5 +1,7 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.ImpactTreeNode;
 import com.jfrog.ide.common.nodes.subentities.License;
 import com.jfrog.ide.common.nodes.subentities.Severity;
@@ -12,10 +14,14 @@ import java.util.List;
 import static com.jfrog.ide.common.utils.Utils.removeComponentIdPrefix;
 
 public class DependencyNode extends SortableChildrenTreeNode implements SubtitledTreeNode, Comparable<DependencyNode> {
+    @JsonProperty()
     private String componentId = "";
+    @JsonProperty()
     private boolean indirect;
+    @JsonProperty()
     private ImpactTreeNode impactPaths;
-    private final List<License> licenses;
+    @JsonProperty()
+    private List<License> licenses;
 
     public DependencyNode() {
         licenses = new ArrayList<>();
@@ -37,11 +43,13 @@ public class DependencyNode extends SortableChildrenTreeNode implements Subtitle
         this.indirect = indirect;
     }
 
+    @JsonGetter()
     @SuppressWarnings("unused")
     public boolean isIndirect() {
         return indirect;
     }
 
+    @JsonGetter()
     public List<License> getLicenses() {
         return licenses;
     }
@@ -61,6 +69,7 @@ public class DependencyNode extends SortableChildrenTreeNode implements Subtitle
         return severity;
     }
 
+    @JsonGetter()
     @SuppressWarnings("unused")
     public ImpactTreeNode getImpactPaths() {
         return impactPaths;

--- a/src/main/java/com/jfrog/ide/common/nodes/FileTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/FileTreeNode.java
@@ -1,12 +1,16 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 
 import java.io.File;
 
 public class FileTreeNode extends SortableChildrenTreeNode implements SubtitledTreeNode, Comparable<FileTreeNode> {
+    @JsonProperty()
     protected String fileName = "";
+    @JsonProperty()
     protected String filePath = "";
+    @JsonProperty()
     protected Severity topSeverity = Severity.Normal;
 
     // Empty constructor for deserialization

--- a/src/main/java/com/jfrog/ide/common/nodes/IssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/IssueNode.java
@@ -1,20 +1,20 @@
 package com.jfrog.ide.common.nodes;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.*;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
 import java.util.UUID;
+import java.util.Vector;
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
         getterVisibility = JsonAutoDetect.Visibility.NONE,
-        setterVisibility = JsonAutoDetect.Visibility.NONE)
+        setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY)
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "uuid")
 public abstract class IssueNode extends DefaultMutableTreeNode implements SubtitledTreeNode, Comparable<IssueNode> {
     // For deserialization
+    @JsonProperty()
     @SuppressWarnings("unused")
     private final String uuid = UUID.randomUUID().toString();
 
@@ -30,6 +30,26 @@ public abstract class IssueNode extends DefaultMutableTreeNode implements Subtit
             return null;
         }
         return (DependencyNode) parent;
+    }
+
+    @JsonGetter("children")
+    public Vector<TreeNode> getChildren() {
+        return children;
+    }
+
+    @JsonGetter("allowsChildren")
+    public boolean getAllowsChildren() {
+        return super.getAllowsChildren();
+    }
+
+    @JsonSetter("children")
+    public void setChildren(Vector<DefaultMutableTreeNode> children) {
+        if (children == null) {
+            return;
+        }
+        for (DefaultMutableTreeNode child : children) {
+            add(child);
+        }
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/common/nodes/LicenseViolationNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/LicenseViolationNode.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 import org.apache.commons.lang3.StringUtils;
 
@@ -14,11 +15,17 @@ public class LicenseViolationNode extends IssueNode {
     private static final String UNKNOWN_LICENCE_FULL_NAME = "Unknown license";
     @SuppressWarnings("FieldCanBeLocal")
     private static final String UNKNOWN_LICENCE_NAME = "Unknown";
+    @JsonProperty()
     private final String fullName;
+    @JsonProperty()
     private final String name;
+    @JsonProperty()
     private List<String> references = new ArrayList<>();
+    @JsonProperty()
     private Severity severity;
+    @JsonProperty()
     private String lastUpdated;
+    @JsonProperty()
     private List<String> watchNames;
 
     // Empty constructor for deserialization

--- a/src/main/java/com/jfrog/ide/common/nodes/SortableChildrenTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/SortableChildrenTreeNode.java
@@ -1,24 +1,23 @@
 package com.jfrog.ide.common.nodes;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.*;
 import org.apache.commons.collections.CollectionUtils;
 
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 import java.util.Comparator;
 import java.util.UUID;
 import java.util.Vector;
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
         getterVisibility = JsonAutoDetect.Visibility.NONE,
-        setterVisibility = JsonAutoDetect.Visibility.NONE)
+        setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY)
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "uuid")
 public class SortableChildrenTreeNode extends DefaultMutableTreeNode {
     // For deserialization
     @SuppressWarnings("unused")
-    private String uuid = UUID.randomUUID().toString();
+    @JsonProperty()
+    private final String uuid = UUID.randomUUID().toString();
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void sortChildren() {
@@ -30,8 +29,18 @@ public class SortableChildrenTreeNode extends DefaultMutableTreeNode {
         }
     }
 
-    @JsonSetter("children")
-    private void setChildren(Vector<DefaultMutableTreeNode> children) {
+    @JsonGetter()
+    public Vector<TreeNode> getChildren() {
+        return children;
+    }
+
+    @JsonGetter()
+    public boolean getAllowsChildren() {
+        return super.getAllowsChildren();
+    }
+
+    @JsonSetter()
+    public void setChildren(Vector<DefaultMutableTreeNode> children) {
         if (children == null) {
             return;
         }

--- a/src/main/java/com/jfrog/ide/common/nodes/VulnerabilityNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/VulnerabilityNode.java
@@ -1,6 +1,7 @@
 package com.jfrog.ide.common.nodes;
 
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.Cve;
 import com.jfrog.ide.common.nodes.subentities.ResearchInfo;
 import com.jfrog.ide.common.nodes.subentities.Severity;
@@ -16,16 +17,27 @@ import static com.jfrog.ide.common.nodes.subentities.Severity.getNotApplicableSe
  * @author yahavi
  */
 public class VulnerabilityNode extends IssueNode {
+    @JsonProperty()
     private String ignoreRuleUrl;
+    @JsonProperty()
     private Severity severity = Severity.Normal;
+    @JsonProperty()
     private List<String> fixedVersions;
+    @JsonProperty()
     private List<String> infectedVersions;
+    @JsonProperty()
     private List<String> references;
+    @JsonProperty()
     private Cve cve;
+    @JsonProperty()
     private String summary;
+    @JsonProperty()
     private String issueId;
+    @JsonProperty()
     private String lastUpdated;
+    @JsonProperty()
     private List<String> watchNames;
+    @JsonProperty()
     private ResearchInfo researchInfo;
 
     @JsonIdentityReference(alwaysAsId = true)

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/Cve.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/Cve.java
@@ -1,13 +1,20 @@
 package com.jfrog.ide.common.nodes.subentities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * @author yahavi
  **/
 public class Cve {
+    @JsonProperty()
     private String cveId;
+    @JsonProperty()
     private String cvssV2Score;
+    @JsonProperty()
     private String cvssV2Vector;
+    @JsonProperty()
     private String cvssV3Score;
+    @JsonProperty()
     private String cvssV3Vector;
 
     @SuppressWarnings("unused")

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactTreeNode.java
@@ -1,13 +1,17 @@
 package com.jfrog.ide.common.nodes.subentities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.jfrog.ide.common.utils.Utils.removeComponentIdPrefix;
 
 public class ImpactTreeNode {
-    String name;
-    List<ImpactTreeNode> children = new ArrayList<>();
+    @JsonProperty()
+    private String name;
+    @JsonProperty()
+    private List<ImpactTreeNode> children = new ArrayList<>();
 
     // Empty constructor for deserialization
     @SuppressWarnings("unused")

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/License.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/License.java
@@ -1,7 +1,11 @@
 package com.jfrog.ide.common.nodes.subentities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class License {
+    @JsonProperty()
     private String name;
+    @JsonProperty()
     private String moreInfoUrl;
 
     // Empty constructor for deserialization

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ResearchInfo.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ResearchInfo.java
@@ -1,12 +1,19 @@
 package com.jfrog.ide.common.nodes.subentities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public class ResearchInfo {
+    @JsonProperty()
     private Severity severity;
+    @JsonProperty()
     private String shortDescription;
+    @JsonProperty()
     private String fullDescription;
+    @JsonProperty()
     private String remediation;
+    @JsonProperty()
     private List<SeverityReason> severityReasons;
 
     // Empty constructor for deserialization

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/SeverityReason.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/SeverityReason.java
@@ -1,8 +1,13 @@
 package com.jfrog.ide.common.nodes.subentities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class SeverityReason {
+    @JsonProperty()
     private String name;
+    @JsonProperty()
     private String description;
+    @JsonProperty()
     private boolean isPositive;
 
     // Empty constructor for deserialization


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Private and protected fields can't be read by ObjectMapper in newer versions of Java by default, so I handled this issue with some annotations, getters and setters.