### PR TITLE
Flat dependency trees

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,9 @@ dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.14'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.13'
-    implementation('com.jfrog:gradle-dep-tree') {
-        version {
-            branch = 'flat-tree'
-        }
-    }
+    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.0.0'
     implementation group: 'commons-io', name: 'commons-io', version: '2.9.0'
     implementation(group: 'com.opencsv', name: 'opencsv', version: '5.7.0') {
         exclude group: 'common-collections', module: 'commons-collections'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,11 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.13'
-    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '2.1.0'
+    implementation('com.jfrog:gradle-dep-tree') {
+        version {
+            branch = 'flat-tree'
+        }
+    }
     implementation group: 'commons-io', name: 'commons-io', version: '2.9.0'
     implementation(group: 'com.opencsv', name: 'opencsv', version: '5.7.0') {
         exclude group: 'common-collections', module: 'commons-collections'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,1 @@
-sourceControl {
-    gitRepository("https://github.com/asafgabai/gradle-dep-tree.git") {
-        producesModule("com.jfrog:gradle-dep-tree")
-    }
-}
-
 rootProject.name = 'ide-plugins-common'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,7 @@
+sourceControl {
+    gitRepository("https://github.com/asafgabai/gradle-dep-tree.git") {
+        producesModule("com.jfrog:gradle-dep-tree")
+    }
+}
+
 rootProject.name = 'ide-plugins-common'

--- a/src/main/java/com/jfrog/ide/common/deptree/DepTree.java
+++ b/src/main/java/com/jfrog/ide/common/deptree/DepTree.java
@@ -1,0 +1,26 @@
+package com.jfrog.ide.common.deptree;
+
+import java.util.Map;
+
+public class DepTree {
+    private final String rootId;
+    // A map of the nodes in the tree by their component IDs
+    private final Map<String, DepTreeNode> nodes;
+
+    public DepTree(String rootId, Map<String, DepTreeNode> nodes) {
+        this.rootId = rootId;
+        this.nodes = nodes;
+    }
+
+    public String getRootId() {
+        return rootId;
+    }
+
+    public Map<String, DepTreeNode> getNodes() {
+        return nodes;
+    }
+
+    public DepTreeNode getRootNode() {
+        return nodes.get(rootId);
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/deptree/DepTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/deptree/DepTreeNode.java
@@ -1,0 +1,38 @@
+package com.jfrog.ide.common.deptree;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DepTreeNode {
+    // Used in nodes that their descriptor files are part of the project only.
+    private String descriptorFilePath;
+    private Set<String> scopes = new HashSet<>();
+    private Set<String> children = new HashSet<>();
+
+    public DepTreeNode descriptorFilePath(String path) {
+        this.descriptorFilePath = path;
+        return this;
+    }
+
+    public DepTreeNode scopes(Set<String> scopes) {
+        this.scopes = scopes;
+        return this;
+    }
+
+    public DepTreeNode children(Set<String> children) {
+        this.children = children;
+        return this;
+    }
+
+    public String getDescriptorFilePath() {
+        return descriptorFilePath;
+    }
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public Set<String> getChildren() {
+        return children;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java
@@ -49,10 +49,10 @@ public class GoTreeBuilder {
     /**
      * Create Go dependency tree of actually used dependencies.
      *
-     * @param goDriver     - Go driver
-     * @param logger       - The logger
-     * @param verbose      - verbose logging
-     * @param dontBuildVcs - Skip VCS stamping - can be used only on Go later than 1.18
+     * @param goDriver     Go driver
+     * @param logger       the logger
+     * @param verbose      verbose logging
+     * @param dontBuildVcs skip VCS stamping - can be used only on Go later than 1.18
      * @return Go dependency tree
      * @throws IOException in case of any I/O error.
      */
@@ -62,8 +62,6 @@ public class GoTreeBuilder {
         CommandResults goGraphResult = goDriver.modGraph(verbose);
         String[] dependenciesGraph = goGraphResult.getRes().split("\\r?\\n");
 
-        // Run go list -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all
-        // This command returns used dependencies only.
         CommandResults usedModulesResults;
         try {
             usedModulesResults = goDriver.getUsedModules(false, false, dontBuildVcs);

--- a/src/main/java/com/jfrog/ide/common/gradle/GradleTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/gradle/GradleTreeBuilder.java
@@ -1,25 +1,19 @@
 package com.jfrog.ide.common.gradle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
-import com.jfrog.GradleDependencyTree;
+import com.jfrog.GradleDepTreeResults;
+import com.jfrog.GradleDependencyNode;
+import com.jfrog.ide.common.deptree.DepTree;
+import com.jfrog.ide.common.deptree.DepTreeNode;
 import org.jfrog.build.api.util.Log;
-import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.GeneralInfo;
-import org.jfrog.build.extractor.scan.License;
-import org.jfrog.build.extractor.scan.Scope;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Build Gradle dependency tree before the Xray scan.
@@ -32,10 +26,12 @@ public class GradleTreeBuilder {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final GradleDriver gradleDriver;
     private final Path projectDir;
+    private final String descriptorFilePath;
     private Path pluginLibDir;
 
-    public GradleTreeBuilder(Path projectDir, Map<String, String> env, String gradleExe) {
+    public GradleTreeBuilder(Path projectDir, String descriptorFilePath, Map<String, String> env, String gradleExe) {
         this.projectDir = projectDir;
+        this.descriptorFilePath = descriptorFilePath;
         this.gradleDriver = new GradleDriver(gradleExe, env);
     }
 
@@ -46,7 +42,7 @@ public class GradleTreeBuilder {
      * @return full dependency tree without Xray scan results.
      * @throws IOException in case of I/O error.
      */
-    public DependencyTree buildTree(Log logger) throws IOException {
+    public DepTree buildTree(Log logger) throws IOException {
         gradleDriver.verifyGradleInstalled();
         List<File> gradleDependenciesFiles = gradleDriver.generateDependenciesGraphAsJson(projectDir.toFile(), logger);
         return createDependencyTrees(gradleDependenciesFiles);
@@ -59,63 +55,30 @@ public class GradleTreeBuilder {
      * @return a dependency tree contain one or more Gradle projects.
      * @throws IOException in case of any I/O error.
      */
-    private DependencyTree createDependencyTrees(List<File> gradleDependenciesFiles) throws IOException {
-        DependencyTree rootNode = new DependencyTree(projectDir.getFileName().toString());
-        rootNode.setMetadata(true);
-        rootNode.setGeneralInfo(new GeneralInfo().componentId(projectDir.getFileName().toString()).path(projectDir.toString()));
+    private DepTree createDependencyTrees(List<File> gradleDependenciesFiles) throws IOException {
+        String rootId = projectDir.getFileName().toString();
+        DepTreeNode rootNode = new DepTreeNode().descriptorFilePath(descriptorFilePath);
+
+        Map<String, DepTreeNode> nodes = new HashMap<>();
         for (File projectFile : gradleDependenciesFiles) {
-            String projectName = new String(Base64.getDecoder().decode(projectFile.getName()), StandardCharsets.UTF_8);
-            GradleDependencyTree node = objectMapper.readValue(projectFile, GradleDependencyTree.class);
-            GeneralInfo generalInfo = createGeneralInfo(projectName, node).path(projectDir.toString());
-            DependencyTree projectNode = createNode(generalInfo, node);
-            projectNode.setMetadata(true);
-            populateDependencyTree(projectNode, node);
-            rootNode.add(projectNode);
+            GradleDepTreeResults results = objectMapper.readValue(projectFile, GradleDepTreeResults.class);
+            for (Map.Entry<String, GradleDependencyNode> nodeEntry : results.getNodes().entrySet()) {
+                String compId = nodeEntry.getKey();
+                GradleDependencyNode gradleDep = nodeEntry.getValue();
+                DepTreeNode node = new DepTreeNode().scopes(gradleDep.getConfigurations()).children(gradleDep.getChildren());
+                nodes.put(compId, node);
+            }
+            nodes.get(results.getRoot()).descriptorFilePath(descriptorFilePath);
+            rootNode.getChildren().add(results.getRoot());
         }
-        if (gradleDependenciesFiles.size() == 1) {
-            rootNode = (DependencyTree) rootNode.getFirstChild();
+        if (rootNode.getChildren().size() == 1) {
+            return new DepTree(rootNode.getChildren().iterator().next(), nodes);
         }
-        return rootNode;
+        nodes.put(rootId, rootNode);
+        return new DepTree(rootId, nodes);
     }
 
-    /**
-     * Recursively populate a Gradle dependency node.
-     *
-     * @param node                 - The dependency node to populate
-     * @param gradleDependencyNode - The Gradle dependency node created by 'generateDependenciesGraphAsJson'
-     */
-    private void populateDependencyTree(DependencyTree node, GradleDependencyTree gradleDependencyNode) {
-        for (Map.Entry<String, GradleDependencyTree> gradleEntry : gradleDependencyNode.getChildren().entrySet()) {
-            GeneralInfo generalInfo = createGeneralInfo(gradleEntry.getKey(), gradleEntry.getValue());
-            DependencyTree child = createNode(generalInfo, gradleEntry.getValue());
-            node.add(child);
-            populateDependencyTree(child, gradleEntry.getValue());
-        }
-    }
-
-    private GeneralInfo createGeneralInfo(String id, GradleDependencyTree node) {
+    private GeneralInfo createGeneralInfo(String id, GradleDependencyNode node) {
         return new GeneralInfo().pkgType("gradle").componentId(id);
-    }
-
-    /**
-     * Create a dependency tree node.
-     *
-     * @param generalInfo          - The dependency General info
-     * @param gradleDependencyNode - The Gradle dependency node created by 'generateDependenciesGraphAsJson'
-     * @return the dependency tree node.
-     */
-    private DependencyTree createNode(GeneralInfo generalInfo, GradleDependencyTree gradleDependencyNode) {
-        DependencyTree node = new DependencyTree(generalInfo.getComponentId());
-        node.setGeneralInfo(generalInfo);
-        Set<Scope> scopes = gradleDependencyNode.getConfigurations().stream().map(Scope::new).collect(Collectors.toSet());
-        if (scopes.isEmpty()) {
-            scopes.add(new Scope());
-        }
-        node.setScopes(scopes);
-        node.setLicenses(Sets.newHashSet(new License()));
-        if (isBlank(generalInfo.getGroupId())) {
-            node.setMetadata(true);
-        }
-        return node;
     }
 }

--- a/src/main/java/com/jfrog/ide/common/gradle/GradleTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/gradle/GradleTreeBuilder.java
@@ -60,16 +60,17 @@ public class GradleTreeBuilder {
         DepTreeNode rootNode = new DepTreeNode().descriptorFilePath(descriptorFilePath);
 
         Map<String, DepTreeNode> nodes = new HashMap<>();
-        for (File projectFile : gradleDependenciesFiles) {
-            GradleDepTreeResults results = objectMapper.readValue(projectFile, GradleDepTreeResults.class);
+        for (File moduleDepsFile : gradleDependenciesFiles) {
+            GradleDepTreeResults results = objectMapper.readValue(moduleDepsFile, GradleDepTreeResults.class);
             for (Map.Entry<String, GradleDependencyNode> nodeEntry : results.getNodes().entrySet()) {
                 String compId = nodeEntry.getKey();
                 GradleDependencyNode gradleDep = nodeEntry.getValue();
                 DepTreeNode node = new DepTreeNode().scopes(gradleDep.getConfigurations()).children(gradleDep.getChildren());
                 nodes.put(compId, node);
             }
-            nodes.get(results.getRoot()).descriptorFilePath(descriptorFilePath);
-            rootNode.getChildren().add(results.getRoot());
+            String moduleRootId = results.getRoot();
+            nodes.get(moduleRootId).descriptorFilePath(descriptorFilePath);
+            rootNode.getChildren().add(moduleRootId);
         }
         if (rootNode.getChildren().size() == 1) {
             return new DepTree(rootNode.getChildren().iterator().next(), nodes);

--- a/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
@@ -14,6 +14,9 @@ import java.util.List;
 import static com.jfrog.ide.common.utils.Utils.removeComponentIdPrefix;
 
 public class DependencyNode extends SortableChildrenTreeNode implements SubtitledTreeNode, Comparable<DependencyNode> {
+    /**
+     * Xray component ID, including a package manager prefix (like npm://)
+     */
     @JsonProperty()
     private String componentId = "";
     @JsonProperty()

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactTreeNode.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.jfrog.ide.common.utils.Utils.removeComponentIdPrefix;
-
 public class ImpactTreeNode {
     @JsonProperty()
     private String name;
@@ -26,16 +24,12 @@ public class ImpactTreeNode {
         return name;
     }
 
-    public String getNameWithoutPrefix() {
-        return removeComponentIdPrefix(name);
-    }
-
     public List<ImpactTreeNode> getChildren() {
         return children;
     }
 
     public boolean contains(String name) {
-        if (getNameWithoutPrefix().contains(name)) {
+        if (this.name.contains(name)) {
             return true;
         }
         for (var child : children) {

--- a/src/main/java/com/jfrog/ide/common/npm/NpmTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/npm/NpmTreeBuilder.java
@@ -34,7 +34,7 @@ public class NpmTreeBuilder {
     /**
      * Build the npm project dependency tree.
      *
-     * @param logger - the logger.
+     * @param logger the logger.
      * @return full dependency tree without Xray scan results.
      * @throws IOException in case of I/O error.
      */
@@ -85,7 +85,7 @@ public class NpmTreeBuilder {
     /**
      * Get root package ID. Typically, "name:version".
      *
-     * @param results - results of 'npm ls' command.
+     * @param results results of 'npm ls' command.
      * @return root package ID.
      */
     private String getPackageId(JsonNode results) throws IOException {

--- a/src/main/java/com/jfrog/ide/common/scan/GraphScanLogic.java
+++ b/src/main/java/com/jfrog/ide/common/scan/GraphScanLogic.java
@@ -76,45 +76,11 @@ public class GraphScanLogic implements ScanLogic {
     }
 
     /**
-     * Create a flat tree of all components required to scan.
-     * Add all direct dependencies to cache to make sure that dependencies will not be scanned again in the next quick scan.
-     *
-     * @param root - The root dependency tree node
-     * @return a graph of non cached component for Xray scan.
-     */
-    private DependencyTree createScanTree(DependencyTree root) {
-        DependencyTree scanTree = new DependencyTree(root.getUserObject());
-        Set<String> componentsAdded = new HashSet<>();
-        populateScanTree(root, scanTree, componentsAdded);
-        return scanTree;
-    }
-
-    /**
-     * Recursively, populate scan tree with the project's dependencies.
-     * The result is a flat tree with only dependencies needed for the Xray scan.
-     *
-     * @param root            - The root dependency tree node
-     * @param scanTree        - The result
-     * @param componentsAdded - Set of added components used to remove duplications
-     */
-    private void populateScanTree(DependencyTree root, DependencyTree scanTree, Set<String> componentsAdded) {
-        for (DependencyTree child : root.getChildren()) {
-            // Don't add metadata nodes to the scan tree
-            if (!child.isMetadata()) {
-                // Add the dependency subtree to the scan tree
-                if (componentsAdded.add(child.getComponentId())) {
-                    scanTree.add(new DependencyTree(child.getComponentId()));
-                }
-            }
-            populateScanTree(child, scanTree, componentsAdded);
-        }
-    }
-
-    /**
      * Create a tree of all components required to scan.
+     * The returned tree is of type {@link DependencyTree} as expected by the Xray client library.
      *
-     * @param tree   - the dependency tree to scan.
-     * @param prefix - components prefix for xray scan, e.g. gav:// or npm://.
+     * @param tree   the dependency tree to scan.
+     * @param prefix components prefix for xray scan, e.g. gav:// or npm://.
      * @return a graph of components for Xray scan.
      */
     private DependencyTree createScanTree(DepTree tree, ComponentPrefix prefix) {
@@ -144,10 +110,10 @@ public class GraphScanLogic implements ScanLogic {
      * A scan without project key may produce a list of licenses and a list of vulnerabilities.
      * The response form Xray will include violations security and licenses (if found) or vulnerabilities according to those watches.
      *
-     * @param xrayClient      - The Xray client.
-     * @param artifactsToScan - The bulk of components to scan.
-     * @param server          - JFrog platform server configuration.
-     * @param checkCanceled   - Callback that throws an exception if scan was cancelled by user
+     * @param xrayClient      the Xray client.
+     * @param artifactsToScan the bulk of components to scan.
+     * @param server          JFrog platform server configuration.
+     * @param checkCanceled   a callback that throws an exception if scan was cancelled by user
      * @throws IOException          in case of connection issues.
      * @throws InterruptedException in case of scan canceled.
      */

--- a/src/main/java/com/jfrog/ide/common/scan/ScanLogic.java
+++ b/src/main/java/com/jfrog/ide/common/scan/ScanLogic.java
@@ -1,14 +1,14 @@
 package com.jfrog.ide.common.scan;
 
 import com.jfrog.ide.common.configuration.ServerConfig;
+import com.jfrog.ide.common.deptree.DepTree;
 import com.jfrog.ide.common.log.ProgressIndicator;
 import com.jfrog.ide.common.nodes.DependencyNode;
-import org.jfrog.build.extractor.scan.DependencyTree;
 
 import java.io.IOException;
 import java.util.Map;
 
 public interface ScanLogic {
-    Map<String, DependencyNode> scanArtifacts(DependencyTree dependencyTree, ServerConfig server, ProgressIndicator indicator, ComponentPrefix prefix, Runnable checkCanceled) throws IOException, InterruptedException;
+    Map<String, DependencyNode> scanArtifacts(DepTree dependencyTree, ServerConfig server, ProgressIndicator indicator, ComponentPrefix prefix, Runnable checkCanceled) throws IOException, InterruptedException;
 }
 

--- a/src/main/java/com/jfrog/ide/common/yarn/YarnTreeBuilder.java
+++ b/src/main/java/com/jfrog/ide/common/yarn/YarnTreeBuilder.java
@@ -120,7 +120,7 @@ public class YarnTreeBuilder {
         if (nameNode != null) {
             packageName = nameNode.asText();
         } else if (projectDir.getFileName() != null) {
-            packageName = projectDir.getFileName().getFileName().toString();
+            packageName = projectDir.getFileName().toString();
         } else {
             return "N/A";
         }

--- a/src/test/java/com/jfrog/ide/common/TestUtils.java
+++ b/src/test/java/com/jfrog/ide/common/TestUtils.java
@@ -1,14 +1,16 @@
 package com.jfrog.ide.common;
 
+import com.jfrog.ide.common.deptree.DepTree;
+import com.jfrog.ide.common.deptree.DepTreeNode;
 import org.jfrog.build.extractor.scan.DependencyTree;
 
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author yahavi
  **/
 public class TestUtils {
-
     /**
      * Get the dependency tree child. Fail the test if it doesn't exist.
      *
@@ -22,6 +24,20 @@ public class TestUtils {
                 .findAny()
                 .orElse(null);
         assertNotNull(childNode, "Couldn't find node '" + childName + "' between " + node + ".");
+        return childNode;
+    }
+
+    /**
+     * Get the dependency tree child. Fail the test if it doesn't exist.
+     *
+     * @param depTree   - The dependency tree
+     * @param childName - The child name to search
+     * @return the dependency tree child.
+     */
+    public static DepTreeNode getAndAssertChild(DepTree depTree, DepTreeNode parent, String childName) {
+        assertTrue(parent.getChildren().contains(childName));
+        DepTreeNode childNode = depTree.getNodes().get(childName);
+        assertNotNull(childNode, "Couldn't find node '" + childName + "'.");
         return childNode;
     }
 }

--- a/src/test/java/com/jfrog/ide/common/TestUtils.java
+++ b/src/test/java/com/jfrog/ide/common/TestUtils.java
@@ -30,8 +30,8 @@ public class TestUtils {
     /**
      * Get the dependency tree child. Fail the test if it doesn't exist.
      *
-     * @param depTree   - The dependency tree
-     * @param childName - The child name to search
+     * @param depTree   the dependency tree
+     * @param childName the child name to search
      * @return the dependency tree child.
      */
     public static DepTreeNode getAndAssertChild(DepTree depTree, DepTreeNode parent, String childName) {

--- a/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
@@ -1,13 +1,12 @@
 package com.jfrog.ide.common.npm;
 
 import com.google.common.collect.Sets;
+import com.jfrog.ide.common.deptree.DepTree;
+import com.jfrog.ide.common.deptree.DepTreeNode;
 import org.apache.commons.io.FileUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.client.Version;
 import org.jfrog.build.extractor.npm.NpmDriver;
-import org.jfrog.build.extractor.scan.DependencyTree;
-import org.jfrog.build.extractor.scan.GeneralInfo;
-import org.jfrog.build.extractor.scan.Scope;
 import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -33,26 +32,11 @@ import static org.testng.Assert.*;
 public class NpmTreeBuilderTest {
     private static final Path NPM_ROOT = Paths.get(".").toAbsolutePath().normalize().resolve(Paths.get("src", "test", "resources", "npm"));
 
-    enum Project {
-        EMPTY("package-name1", "empty", false),
-        DEPENDENCY("package-name2", "dependency", true),
-        DEPENDENCY_PACKAGE_LOCK("package-name3", "dependencyPackageLock", true),
-        DEV_AND_PROD("package-name4", "devAndProd", true);
-
-        private final boolean hasChildren;
-        private final String name;
-        private final Path path;
-
-        Project(String name, String path, boolean hasChildren) {
-            this.name = name;
-            this.path = NPM_ROOT.resolve(path);
-            this.hasChildren = hasChildren;
-        }
-    }
+    private DepTree depTree;
 
     private final NpmDriver npmDriver = new NpmDriver(null);
     private final boolean isNpm7 = isNpm7();
-    private DependencyTree dependencyTree;
+    private String descriptorFilePath;
     private File tempProject;
 
     @BeforeMethod
@@ -66,12 +50,28 @@ public class NpmTreeBuilderTest {
             if ((Boolean) testArgs[1]) {
                 npmDriver.install(tempProject, Lists.newArrayList(), null);
             }
-            NpmTreeBuilder npmTreeBuilder = new NpmTreeBuilder(tempProject.toPath(), null);
-            dependencyTree = npmTreeBuilder.buildTree(new NullLog());
-            assertNotNull(dependencyTree);
+            Path projectDir = tempProject.toPath();
+            descriptorFilePath = projectDir.resolve("package.json").toString();
+            NpmTreeBuilder npmTreeBuilder = new NpmTreeBuilder(projectDir, descriptorFilePath, null);
+            depTree = npmTreeBuilder.buildTree(new NullLog());
+            assertNotNull(depTree);
         } catch (IOException e) {
             fail(e.getMessage(), e);
         }
+    }
+
+    @DataProvider
+    private Object[][] npm6TreeBuilderProvider() {
+        return new Object[][]{
+                {Project.EMPTY, 0},
+                {Project.EMPTY, 0},
+                {Project.DEPENDENCY, 0},
+                {Project.DEPENDENCY, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
+                {Project.DEV_AND_PROD, 0},
+                {Project.DEV_AND_PROD, 1},
+        };
     }
 
     @AfterMethod
@@ -79,113 +79,99 @@ public class NpmTreeBuilderTest {
         FileUtils.deleteQuietly(tempProject);
     }
 
-    @DataProvider
-    private Object[][] npm6TreeBuilderProvider() {
-        return new Object[][]{
-                {Project.EMPTY, false, 0},
-                {Project.EMPTY, true, 0},
-                {Project.DEPENDENCY, false, 0},
-                {Project.DEPENDENCY, true, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, false, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, true, 2},
-                {Project.DEV_AND_PROD, false, 0},
-                {Project.DEV_AND_PROD, true, 1},
-        };
-    }
-
     @Test(dataProvider = "npm6TreeBuilderProvider")
-    public void npm6TreeBuilderTest(Project project, boolean install, int expectedChildren) {
+    public void npm6TreeBuilderTest(Project project, int expectedChildren) {
         if (isNpm7()) {
             throw new SkipException("Skip test on npm >= 7");
         }
 
-        String expectedProjectName = project.name;
-        if (!install && project.hasChildren) {
-            expectedProjectName += " (Not installed)";
-        }
-        checkDependencyTree(expectedProjectName, expectedChildren);
+        String expectedProjectId = project.packageId;
+        checkDependencyTree(expectedProjectId, expectedChildren);
     }
 
     @DataProvider
     private Object[][] npm7TreeBuilderProvider() {
         return new Object[][]{
-                {Project.EMPTY, true, 0},
-                {Project.DEPENDENCY, false, 0},
-                {Project.DEPENDENCY, true, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, false, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, true, 2},
-                {Project.DEV_AND_PROD, false, 0},
-                {Project.DEV_AND_PROD, true, 1},
+                {Project.EMPTY, 0},
+                {Project.DEPENDENCY, 0},
+                {Project.DEPENDENCY, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
+                {Project.DEV_AND_PROD, 0},
+                {Project.DEV_AND_PROD, 1},
         };
     }
 
     @SuppressWarnings("unused")
     @Test(dataProvider = "npm7TreeBuilderProvider")
-    public void npm7TreeBuilderTest(Project project, boolean install, int expectedChildren) {
+    public void npm7TreeBuilderTest(Project project, int expectedChildren) {
         if (!isNpm7()) {
             throw new SkipException("Skip test on npm < 7");
         }
-        String expectedProjectName = project.name;
+        String expectedProjectId = project.packageId;
         boolean packageLockExist = Files.exists(tempProject.toPath().resolve("package-lock.json"));
-        if (!packageLockExist) {
-            expectedProjectName += " (Not installed)";
-        }
-        checkDependencyTree(expectedProjectName, expectedChildren);
+        checkDependencyTree(expectedProjectId, expectedChildren);
     }
 
-    private void checkDependencyTree(String expectedProjectName, int expectedChildren) {
-        checkGeneralInfo(dependencyTree.getGeneralInfo(), expectedProjectName, tempProject);
-        assertEquals(dependencyTree.getChildren().size(), expectedChildren);
+    private void checkDependencyTree(String expectedProjectId, int expectedChildren) {
+        assertNotNull(depTree);
+        assertEquals(depTree.getRootId(), expectedProjectId);
+        DepTreeNode rootNode = depTree.getRootNode();
+        assertNotNull(rootNode);
+        assertEquals(rootNode.getDescriptorFilePath(), descriptorFilePath);
+        assertEquals(rootNode.getChildren().size(), expectedChildren);
         switch (expectedChildren) {
-            case 0:
-                noChildrenScenario(dependencyTree);
-                break;
             case 1:
-                oneChildScenario(dependencyTree, expectedProjectName);
+                oneChildScenario();
                 break;
             case 2:
-                twoChildrenScenario(dependencyTree, expectedProjectName);
+                twoChildrenScenario();
         }
     }
 
-    private void checkGeneralInfo(GeneralInfo actual, String name, File path) {
-        assertNotNull(actual);
-        assertEquals(actual.getComponentId(), name + ":" + "0.0.1");
-        assertEquals(actual.getPath(), path.toString());
-        assertEquals(actual.getPkgType(), "npm");
-        assertEquals(actual.getArtifactId(), name);
-        assertEquals(actual.getVersion(), "0.0.1");
-    }
-
-    private void noChildrenScenario(DependencyTree dependencyTree) {
-        assertTrue(dependencyTree.isLeaf());
-    }
-
-    private void oneChildScenario(DependencyTree dependencyTree, String expectedProjectName) {
-        DependencyTree child = dependencyTree.getChildren().get(0);
-        assertEquals("progress:2.0.3", child.toString());
-        Set<Scope> expectedScopes = Sets.newHashSet(new Scope("dev"));
+    private void oneChildScenario() {
+        DepTreeNode rootNode = depTree.getRootNode();
+        String childId = rootNode.getChildren().stream().findFirst().orElse(null);
+        assertEquals("progress:2.0.3", childId);
+        DepTreeNode childNode = depTree.getNodes().get(childId);
+        assertNotNull(childNode);
+        Set<String> expectedScopes = Sets.newHashSet("dev");
         // If using npm 6, the dependency may be either in dev and prod scopes
         if (!isNpm7) {
-            expectedScopes.add(new Scope("prod"));
+            expectedScopes.add("prod");
         }
-        assertEquals(child.getScopes(), expectedScopes);
-        assertEquals(child.getParent().toString(), expectedProjectName);
+        assertEquals(childNode.getScopes(), expectedScopes);
     }
 
-    private void twoChildrenScenario(DependencyTree dependencyTree, String expectedProjectName) {
-        for (DependencyTree child : dependencyTree.getChildren()) {
-            switch (child.toString()) {
+    private void twoChildrenScenario() {
+        DepTreeNode rootNode = depTree.getRootNode();
+        for (String childId : rootNode.getChildren()) {
+            DepTreeNode childNode = depTree.getNodes().get(childId);
+            switch (childId) {
                 case "progress:2.0.3":
-                    assertTrue(child.getScopes().contains(new Scope("prod")));
+                    assertTrue(childNode.getScopes().contains("prod"));
                     break;
                 case "debug:4.1.1":
-                    assertEquals(child.getScopes(), Sets.newHashSet(new Scope("dev")));
+                    assertEquals(childNode.getScopes(), Sets.newHashSet("dev"));
                     break;
                 default:
-                    fail("Unexpected dependency " + child);
+                    fail("Unexpected dependency " + childId);
             }
-            assertEquals(child.getParent().toString(), expectedProjectName);
+        }
+    }
+
+    enum Project {
+        EMPTY("package-name1:0.0.1", "empty"),
+        DEPENDENCY("package-name2:0.0.1", "dependency"),
+        DEPENDENCY_PACKAGE_LOCK("package-name3:0.0.1", "dependencyPackageLock"),
+        DEV_AND_PROD("package-name4:0.0.1", "devAndProd");
+
+        private final String packageId;
+        private final Path path;
+
+        Project(String packageId, String path) {
+            this.packageId = packageId;
+            this.path = NPM_ROOT.resolve(path);
         }
     }
 

--- a/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
+++ b/src/test/java/com/jfrog/ide/common/npm/NpmTreeBuilderTest.java
@@ -63,14 +63,14 @@ public class NpmTreeBuilderTest {
     @DataProvider
     private Object[][] npm6TreeBuilderProvider() {
         return new Object[][]{
-                {Project.EMPTY, 0},
-                {Project.EMPTY, 0},
-                {Project.DEPENDENCY, 0},
-                {Project.DEPENDENCY, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
-                {Project.DEV_AND_PROD, 0},
-                {Project.DEV_AND_PROD, 1},
+                {Project.EMPTY, false, 0},
+                {Project.EMPTY, true, 0},
+                {Project.DEPENDENCY, false, 0},
+                {Project.DEPENDENCY, true, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, false, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, true, 2},
+                {Project.DEV_AND_PROD, false, 0},
+                {Project.DEV_AND_PROD, true, 1},
         };
     }
 
@@ -79,8 +79,9 @@ public class NpmTreeBuilderTest {
         FileUtils.deleteQuietly(tempProject);
     }
 
+    @SuppressWarnings("unused")
     @Test(dataProvider = "npm6TreeBuilderProvider")
-    public void npm6TreeBuilderTest(Project project, int expectedChildren) {
+    public void npm6TreeBuilderTest(Project project, boolean install, int expectedChildren) {
         if (isNpm7()) {
             throw new SkipException("Skip test on npm >= 7");
         }
@@ -92,19 +93,19 @@ public class NpmTreeBuilderTest {
     @DataProvider
     private Object[][] npm7TreeBuilderProvider() {
         return new Object[][]{
-                {Project.EMPTY, 0},
-                {Project.DEPENDENCY, 0},
-                {Project.DEPENDENCY, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
-                {Project.DEPENDENCY_PACKAGE_LOCK, 2},
-                {Project.DEV_AND_PROD, 0},
-                {Project.DEV_AND_PROD, 1},
+                {Project.EMPTY, true, 0},
+                {Project.DEPENDENCY, false, 0},
+                {Project.DEPENDENCY, true, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, false, 2},
+                {Project.DEPENDENCY_PACKAGE_LOCK, true, 2},
+                {Project.DEV_AND_PROD, false, 0},
+                {Project.DEV_AND_PROD, true, 1},
         };
     }
 
     @SuppressWarnings("unused")
     @Test(dataProvider = "npm7TreeBuilderProvider")
-    public void npm7TreeBuilderTest(Project project, int expectedChildren) {
+    public void npm7TreeBuilderTest(Project project, boolean install, int expectedChildren) {
         if (!isNpm7()) {
             throw new SkipException("Skip test on npm < 7");
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
A new structure for the dependency trees: created a new class for dependency trees (DepTree) that has a flat tree structure to save memory.

Depends on https://github.com/jfrog/gradle-dep-tree/pull/14