### PR TITLE
Fix duplications in results cache

### DIFF
--- a/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
@@ -31,7 +31,7 @@ public class ApplicableIssueNode extends FileIssueNode {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ApplicableIssueNode that = (ApplicableIssueNode) o;
-        return Objects.equals(scannerSearchTarget, that.scannerSearchTarget) && Objects.equals(issue, that.issue);
+        return super.equals(o) && Objects.equals(scannerSearchTarget, that.scannerSearchTarget) && Objects.equals(issue, that.issue);
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
@@ -1,12 +1,15 @@
 package com.jfrog.ide.common.nodes;
 
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.SourceCodeScanType;
+import lombok.Getter;
 
+@Getter
 public class ApplicableIssueNode extends FileIssueNode {
     @JsonProperty()
     private String scannerSearchTarget;
-    @JsonProperty()
+    @JsonIdentityReference(alwaysAsId = true)
     private VulnerabilityNode issue;
 
     // Empty constructor for deserialization
@@ -18,14 +21,5 @@ public class ApplicableIssueNode extends FileIssueNode {
         super(name, filePath, rowStart, colStart, rowEnd, colEnd, reason, lineSnippet, SourceCodeScanType.CONTEXTUAL, issue.getSeverity());
         this.scannerSearchTarget = scannerSearchTarget;
         this.issue = issue;
-    }
-
-    public VulnerabilityNode getIssue() {
-        return issue;
-    }
-
-
-    public String getScannerSearchTarget() {
-        return scannerSearchTarget;
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ApplicableIssueNode.java
@@ -5,10 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.SourceCodeScanType;
 import lombok.Getter;
 
+import java.util.Objects;
+
 @Getter
 public class ApplicableIssueNode extends FileIssueNode {
     @JsonProperty()
     private String scannerSearchTarget;
+    @JsonProperty()
     @JsonIdentityReference(alwaysAsId = true)
     private VulnerabilityNode issue;
 
@@ -21,5 +24,18 @@ public class ApplicableIssueNode extends FileIssueNode {
         super(name, filePath, rowStart, colStart, rowEnd, colEnd, reason, lineSnippet, SourceCodeScanType.CONTEXTUAL, issue.getSeverity());
         this.scannerSearchTarget = scannerSearchTarget;
         this.issue = issue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApplicableIssueNode that = (ApplicableIssueNode) o;
+        return Objects.equals(scannerSearchTarget, that.scannerSearchTarget) && Objects.equals(issue, that.issue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scannerSearchTarget, issue);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
@@ -156,11 +156,11 @@ public class DependencyNode extends SortableChildrenTreeNode implements Subtitle
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DependencyNode that = (DependencyNode) o;
-        return indirect == that.indirect && Objects.equals(componentId, that.componentId) && Objects.equals(impactPaths, that.impactPaths) && Objects.equals(licenses, that.licenses) && Objects.equals(children, that.children);
+        return indirect == that.indirect && Objects.equals(componentId, that.componentId) && Objects.equals(impactTree, that.impactTree) && Objects.equals(licenses, that.licenses) && Objects.equals(children, that.children);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(componentId, indirect, impactPaths, licenses, children);
+        return Objects.hash(componentId, indirect, impactTree, licenses, children);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
@@ -161,6 +161,6 @@ public class DependencyNode extends SortableChildrenTreeNode implements Subtitle
 
     @Override
     public int hashCode() {
-        return Objects.hash(componentId, indirect, impactPaths, licenses);
+        return Objects.hash(componentId, indirect, impactPaths, licenses, children);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/DependencyNode.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import javax.swing.tree.TreeNode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.jfrog.ide.common.utils.Utils.removeComponentIdPrefix;
 
@@ -148,5 +149,18 @@ public class DependencyNode extends SortableChildrenTreeNode implements Subtitle
     @Override
     public String toString() {
         return getTitle();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DependencyNode that = (DependencyNode) o;
+        return indirect == that.indirect && Objects.equals(componentId, that.componentId) && Objects.equals(impactPaths, that.impactPaths) && Objects.equals(licenses, that.licenses) && Objects.equals(children, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(componentId, indirect, impactPaths, licenses);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/FileIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/FileIssueNode.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.SourceCodeScanType;
 import com.jfrog.ide.common.nodes.subentities.Severity;
 
+import java.util.Objects;
+
 public class FileIssueNode extends IssueNode implements SubtitledTreeNode {
     @JsonProperty()
     private String title;
@@ -101,5 +103,18 @@ public class FileIssueNode extends IssueNode implements SubtitledTreeNode {
     @Override
     public String getIcon() {
         return getSeverity().getIconName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileIssueNode that = (FileIssueNode) o;
+        return rowStart == that.rowStart && colStart == that.colStart && rowEnd == that.rowEnd && colEnd == that.colEnd && Objects.equals(title, that.title) && Objects.equals(reason, that.reason) && Objects.equals(lineSnippet, that.lineSnippet) && Objects.equals(filePath, that.filePath) && severity == that.severity && reporterType == that.reporterType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, reason, lineSnippet, rowStart, colStart, rowEnd, colEnd, filePath, severity, reporterType);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/FileTreeNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/FileTreeNode.java
@@ -2,12 +2,15 @@ package com.jfrog.ide.common.nodes;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jfrog.ide.common.nodes.subentities.Severity;
+import lombok.Getter;
 
 import java.io.File;
+import java.util.Objects;
 
 public class FileTreeNode extends SortableChildrenTreeNode implements SubtitledTreeNode, Comparable<FileTreeNode> {
     @JsonProperty()
     protected String fileName = "";
+    @Getter
     @JsonProperty()
     protected String filePath = "";
     @JsonProperty()
@@ -47,10 +50,6 @@ public class FileTreeNode extends SortableChildrenTreeNode implements SubtitledT
         return topSeverity.getIconName();
     }
 
-    public String getFilePath() {
-        return filePath;
-    }
-
     public void addIssue(IssueNode issue) {
         add(issue);
         if (issue.getSeverity().isHigherThan(topSeverity)) {
@@ -61,5 +60,18 @@ public class FileTreeNode extends SortableChildrenTreeNode implements SubtitledT
     @Override
     public int compareTo(FileTreeNode other) {
         return other.getSeverity().ordinal() - this.getSeverity().ordinal();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileTreeNode that = (FileTreeNode) o;
+        return Objects.equals(fileName, that.fileName) && Objects.equals(filePath, that.filePath) && topSeverity == that.topSeverity && Objects.equals(children, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileName, filePath, topSeverity, children);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/Severity.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/Severity.java
@@ -1,11 +1,12 @@
 package com.jfrog.ide.common.nodes.subentities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
 
 /**
  * @author yahavi
  */
+@Getter
 public enum Severity {
     Normal("Scanned - No Issues", "normal"),
     Pending("Pending Scan", "pending"),
@@ -29,54 +30,31 @@ public enum Severity {
         this.iconName = iconName;
     }
 
-    public String getSeverityName() {
-        return this.severityName;
-    }
-
-    public String getIconName() {
-        return iconName;
-    }
-
     public boolean isHigherThan(Severity other) {
         return this.ordinal() > other.ordinal();
     }
 
     @JsonCreator
     public static Severity fromString(String inputSeverity) {
-        for (Severity severity : Severity.values()) {
-            if (severity.getSeverityName().equalsIgnoreCase(inputSeverity)) {
-                return severity;
-            }
-        }
-        throw new IllegalArgumentException("Severity " + inputSeverity + " doesn't exist");
+        return Severity.valueOf(inputSeverity);
     }
 
     public static Severity fromSarif(String level) {
-        switch (level) {
-            case "error":
-                return Severity.High;
-            case "note":
-                return Severity.Low;
-            case "none":
-                return Severity.Unknown;
-            default:
-                return Severity.Medium;
-        }
+        return switch (level) {
+            case "error" -> Severity.High;
+            case "note" -> Severity.Low;
+            case "none" -> Severity.Unknown;
+            default -> Severity.Medium;
+        };
     }
 
     public static Severity getNotApplicableSeverity(Severity severity) {
-        switch (severity) {
-            case Low:
-                return LowNotApplic;
-            case Medium:
-                return MediumNotApplic;
-            case High:
-                return HighNotApplic;
-            case Critical:
-                return CriticalNotApplic;
-            case Unknown:
-            default:
-                return UnknownNotApplic;
-        }
+        return switch (severity) {
+            case Low -> LowNotApplic;
+            case Medium -> MediumNotApplic;
+            case High -> HighNotApplic;
+            case Critical -> CriticalNotApplic;
+            default -> UnknownNotApplic;
+        };
     }
 }

--- a/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
+++ b/src/main/java/com/jfrog/ide/common/persistency/ScanCache.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.jfrog.ide.common.log.Utils;
 import com.jfrog.ide.common.nodes.FileTreeNode;
+import lombok.Getter;
 import org.jfrog.build.api.util.Log;
 
 import java.io.File;
@@ -27,6 +28,7 @@ import static com.jfrog.ide.common.utils.Utils.createMapper;
 public class ScanCache {
     private final File file;
     private final ObjectMapper objectMapper;
+    @Getter
     private ScanCacheObject scanCacheObject;
 
     /**
@@ -66,10 +68,6 @@ public class ScanCache {
     public void cacheNodes(List<FileTreeNode> nodes) throws IOException {
         scanCacheObject = new ScanCacheObject(nodes, System.currentTimeMillis());
         objectMapper.writeValue(file, scanCacheObject);
-    }
-
-    public ScanCacheObject getScanCacheObject() {
-        return scanCacheObject;
     }
 
     public void deleteScanCacheObject() throws IOException {

--- a/src/test/java/com/jfrog/ide/common/persistency/ScanCacheTest.java
+++ b/src/test/java/com/jfrog/ide/common/persistency/ScanCacheTest.java
@@ -1,0 +1,100 @@
+package com.jfrog.ide.common.persistency;
+
+import com.jfrog.ide.common.nodes.*;
+import com.jfrog.ide.common.nodes.subentities.Cve;
+import com.jfrog.ide.common.nodes.subentities.ResearchInfo;
+import com.jfrog.ide.common.nodes.subentities.Severity;
+import com.jfrog.ide.common.nodes.subentities.SeverityReason;
+import org.apache.commons.io.FileUtils;
+import org.jfrog.build.api.util.NullLog;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScanCacheTest {
+    private Path tempCacheDirPath;
+
+    @BeforeMethod
+    public void setUp(Object[] testArgs) throws IOException {
+        tempCacheDirPath = Files.createTempDirectory("ide-plugins-common-test-cache");
+        FileUtils.forceDeleteOnExit(tempCacheDirPath.toFile());
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        FileUtils.forceDelete(tempCacheDirPath.toFile());
+    }
+
+    @Test
+    public void cacheTest() throws IOException {
+        final String TEST_PROJECT_ID = "test-project-id";
+        List<FileTreeNode> fileTreeNodes = getFileTreeNode();
+
+        // Create a new cache and validate it's empty
+        ScanCache cache = new ScanCache(TEST_PROJECT_ID, tempCacheDirPath, new NullLog());
+        Assert.assertNull(cache.getScanCacheObject());
+
+        // Save FileTreeNodes in cache and read them for it
+        cache.cacheNodes(fileTreeNodes);
+        ScanCache newCache = new ScanCache(TEST_PROJECT_ID, tempCacheDirPath, new NullLog());
+        List<FileTreeNode> actual = newCache.getScanCacheObject().getFileTreeNodes();
+        Assert.assertEquals(actual, fileTreeNodes);
+    }
+
+    private static List<FileTreeNode> getFileTreeNode() {
+        List<FileTreeNode> fileTreeNodes = new ArrayList<>();
+        DescriptorFileTreeNode descriptorFileTreeNode = new DescriptorFileTreeNode("path/to/descriptor.xml");
+        VulnerabilityNode vulnerabilityNode = new VulnerabilityNode(
+                "issueId",
+                Severity.LowNotApplic,
+                "summary",
+                new ArrayList<>(List.of("fixedVersions")),
+                new ArrayList<>(List.of("infectedVersions")),
+                new Cve("cveId",
+                        "cvssV2Score",
+                        "cvssV2Vector",
+                        "cvssV3Score",
+                        "cvssV3Vector"),
+                "lastUpdated",
+                new ArrayList<>(List.of("watchNames")),
+                new ArrayList<>(List.of("references")),
+                new ResearchInfo(Severity.Low,
+                        "shortDescription",
+                        "fullDescription",
+                        "remediation",
+                        new ArrayList<>(List.of(new SeverityReason("name", "description", true)))),
+                "ignoreRuleUrl");
+        DependencyNode dependencyNode = new DependencyNode().componentId("componentId");
+        dependencyNode.addIssue(vulnerabilityNode);
+        descriptorFileTreeNode.addDependency(dependencyNode);
+        FileTreeNode fileTreeNode = new FileTreeNode("path/to/file.txt");
+        ApplicableIssueNode applicableIssueNode = new ApplicableIssueNode(
+                "name",
+                1,
+                2,
+                3,
+                4,
+                "filePath",
+                "reason",
+                "lineSnippet",
+                "scannerSearchTarget",
+                vulnerabilityNode
+        );
+        vulnerabilityNode.updateApplicableInfo(applicableIssueNode);
+        fileTreeNode.addIssue(applicableIssueNode);
+
+        // The order of the adding to the list is important! We add the ApplicableIssueNode first to make sure its
+        // 'issue' field is saved in the cache file as a UUID only (a pointer), even though the VulnerabilityNode that
+        // it refers to is written later in the file.
+        fileTreeNodes.add(fileTreeNode);
+        fileTreeNodes.add(descriptorFileTreeNode);
+        return fileTreeNodes;
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Fix duplications of VulnerabilityNodes in the cache, that caused errors while trying to read it.
Usually, a VulnerabilityNode is written to the cache file once: as a child of a DescriptorFileTreeNode.
If there's an ApplicableIssueNode pointing to it, then this ApplicableIssueNode contains a field with the VulnerabilityNode's UUID.
But sometimes, if the ApplicableIssueNode pointing to this VulnerabilityNode has been written before the VulnerabilityNode, then the VulnerabilityNode is written inside the ApplicableIssueNode (instead of just its UUID), and later when the DescriptorFileTreeNode (that contains this VulnerabilityNode) is written, then the VulnerabilityNode is written again.
Both times the VulnerabilityNode is written with the same UUID (because it's the same object), so when the cache is read, a parsing error is thrown, saying there are multiple objects with the same UUID.
To fix that, I added an annotation that enforces writing the VulnerabilityNode, that's inside the ApplicableIssueNode, as a UUID only.