### PR TITLE
Fix errors when scanning projects using Gradle <7.6

### DIFF
--- a/src/main/resources/gradle-dep-tree.gradle
+++ b/src/main/resources/gradle-dep-tree.gradle
@@ -2,7 +2,7 @@ import com.jfrog.GradleDepTree
 
 initscript {
     dependencies {
-        classpath fileTree(System.getenv("pluginLibDir"))
+        classpath fileTree(dir: System.getenv("pluginLibDir"), includes: ['gradle-dep-tree-*.jar'])
     }
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Avoid adding unnecessary libraries to the classpath in the init.gradle file we use for executing gradle-dep-tree.
This caused projects using Gradle <7.6 to fail, because some of these unnecessary libraries were using JDK >=14, which is not supported by it.