### PR TITLE
Support for downloading scan resources from an external repository

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliServerConfig.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliServerConfig.java
@@ -87,7 +87,7 @@ public class JfrogCliServerConfig implements ServerConfig {
     }
 
     @Override
-    public ProxyConfiguration getProxyConfForTargetUrl(String xrayUrl) {
+    public ProxyConfiguration getProxyConfForTargetUrl(String targetUrl) {
         return null;
     }
 
@@ -99,6 +99,11 @@ public class JfrogCliServerConfig implements ServerConfig {
     @Override
     public int getConnectionTimeout() {
         return 0;
+    }
+
+    @Override
+    public String getCustomResourcesRepo() {
+        return null;
     }
 
     private String getValueFromJson(String fieldName) {

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliServerConfig.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliServerConfig.java
@@ -102,7 +102,7 @@ public class JfrogCliServerConfig implements ServerConfig {
     }
 
     @Override
-    public String getCustomResourcesRepo() {
+    public String getExternalResourcesRepo() {
         return null;
     }
 

--- a/src/main/java/com/jfrog/ide/common/configuration/ServerConfig.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/ServerConfig.java
@@ -53,12 +53,12 @@ public interface ServerConfig {
     SSLContext getSslContext();
 
     /**
-     * Reads the http proxy configuration set in IDE configuration and returns the proxy configuration for the Xray URL.
+     * Reads the HTTP proxy configuration set in IDE configuration and returns the proxy configuration for the target URL.
      *
-     * @param xrayUrl - Xray url.
-     * @return proxy config for the Xray URL.
+     * @param targetUrl The target URL.
+     * @return Proxy configuration for the target URL.
      */
-    ProxyConfiguration getProxyConfForTargetUrl(String xrayUrl);
+    ProxyConfiguration getProxyConfForTargetUrl(String targetUrl);
 
     /**
      * @return connection retries.
@@ -69,6 +69,13 @@ public interface ServerConfig {
      * @return connection timeout.
      */
     int getConnectionTimeout();
+
+    /**
+     * Returns custom resources repository name. If it's not configured, null is returned.
+     *
+     * @return Custom resources repository name, if configured.
+     */
+    String getCustomResourcesRepo();
 
     @SuppressWarnings("unused")
     default boolean areCredentialsSet() {

--- a/src/main/java/com/jfrog/ide/common/configuration/ServerConfig.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/ServerConfig.java
@@ -71,11 +71,11 @@ public interface ServerConfig {
     int getConnectionTimeout();
 
     /**
-     * Returns custom resources repository name. If it's not configured, null is returned.
+     * Returns external resources repository name. If it's not configured, null is returned.
      *
-     * @return Custom resources repository name, if configured.
+     * @return External resources repository name, if configured.
      */
-    String getCustomResourcesRepo();
+    String getExternalResourcesRepo();
 
     @SuppressWarnings("unused")
     default boolean areCredentialsSet() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Added a custom resources repository option in the plugin's configuration.