### PR TITLE
Fixed comparison between SastIssueNodes

### DIFF
--- a/src/main/java/com/jfrog/ide/common/nodes/SastIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/SastIssueNode.java
@@ -6,6 +6,8 @@ import com.jfrog.ide.common.nodes.subentities.Severity;
 import com.jfrog.ide.common.nodes.subentities.SourceCodeScanType;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 public class SastIssueNode extends FileIssueNode {
     @JsonProperty()
@@ -19,5 +21,21 @@ public class SastIssueNode extends FileIssueNode {
     public SastIssueNode(String name, String filePath, int rowStart, int colStart, int rowEnd, int colEnd, String reason, String lineSnippet, FindingInfo[][] codeFlows, Severity severity, String ruleID) {
         super(name, filePath, rowStart, colStart, rowEnd, colEnd, reason, lineSnippet, SourceCodeScanType.SAST, severity, ruleID);
         this.codeFlows = codeFlows;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        SastIssueNode that = (SastIssueNode) o;
+        return Arrays.deepEquals(codeFlows, that.codeFlows);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.deepHashCode(codeFlows);
+        return result;
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Addressed an issue where IDEA navigation tab displayed empty nodes for identical SAST nodes with different codeFlows. The fix ensures that the same SAST issue now appears several times as the correct number of codeFlows, each having a distinct trace.