### PR TITLE
Updated build-info version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.41.6'
+def buildInfoVersion = '2.41.9'
 dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Update build-info version to 2.41.9, addressing a Windows issue where running Go commands could fail if the executable was located in a path with spaces.