### PR TITLE
Fix running executables with spaces in their paths in Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.41.9'
+def buildInfoVersion = '2.41.13'
 dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Update build-info version to 2.41.13
Updating build-info version to apply the fix for this issue: https://github.com/jfrog/build-info/pull/777