### PR TITLE
Make cli tests use real JFrog enviornment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: Test
-
 on: [push, pull_request]
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -11,11 +9,15 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         node: [18, 20, 22]
         go: [1.23, 1.24]
+    env:
+      JFROG_CLI_TEST_PASSWORD: ${{ secrets.JFROG_CLI_TEST_PASSWORD }}
+      JFROG_CLI_TEST_USER: ${{ secrets.JFROG_CLI_TEST_USER }}
+      JFROG_CLI_TEST_URL: ${{ secrets.JFROG_CLI_TEST_URL }}
+      JFROG_CLI_TEST_ACCESS_TOKEN: ${{ secrets.JFROG_CLI_TEST_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
       # Install required tools
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -35,7 +37,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-
       # Run tests
       - name: Tests on macOS, Linux
         run: ./gradlew clean test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+
       # Install required tools
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test
+
 on: [push, pull_request]
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -136,12 +136,11 @@ public class JfrogCliDriverTest {
 
     @Test
     public void testAddCliServerConfig_withAccessToken() {
-        String accessToken = UUID.randomUUID().toString();
         try {
             jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, ACCESS_TOKEN, tempDir);
             JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList());
             assertNotNull(serverConfig);
-            assertEquals(serverConfig.getAccessToken(), accessToken);
+            assertEquals(serverConfig.getAccessToken(), ACCESS_TOKEN);
             assertEquals(serverConfig.getArtifactoryUrl(), ARTIFACTORY_URL);
             assertEquals(serverConfig.getXrayUrl(), XRAY_URL);
         } catch (IOException e) {

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -47,6 +47,8 @@ public class JfrogCliDriverTest {
             assertEquals(serverConfig.getUsername(), USER_NAME);
             assertEquals(serverConfig.getPassword(), PASSWORD);
             assertEquals(serverConfig.getUrl(), SERVER_URL);
+            System.out.println("srver url" +SERVER_URL);
+            System.out.println("xray url" + serverConfig.getXrayUrl());
             assertEquals(serverConfig.getXrayUrl(), SERVER_URL + "xray/");
         } catch (IOException e) {
             fail(e.getMessage(), e);

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -30,9 +30,10 @@ public class JfrogCliDriverTest {
     private final SimpleDateFormat timeStampFormat = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss");
     private final Map<String, String> testEnv = new HashMap<>();
     private JfrogCliDriver jfrogCliDriver;
-    private final String PASSWORD = "ide-plugins-common-test-password";
-    private final String USER_NAME = "ide-plugins-common-test-user";
-    private final String SERVER_URL = "https://ide/plugins/common/test/";
+    private final String PASSWORD = System.getenv("JFROG_CLI_TEST_PASSWORD");
+    private final String USER_NAME = System.getenv("JFROG_CLI_TEST_USER");
+    private final String SERVER_URL = System.getenv("JFROG_CLI_TEST_URL");
+    private final String ACCESS_TOKEN = System.getenv("JFROG_CLI_TEST_ACCESS_TOKEN");
     private final String ARTIFACTORY_URL = SERVER_URL + "artifactory/";
     private final String XRAY_URL = SERVER_URL + "xray/";
     private String testServerId;
@@ -137,7 +138,7 @@ public class JfrogCliDriverTest {
     public void testAddCliServerConfig_withAccessToken() {
         String accessToken = UUID.randomUUID().toString();
         try {
-            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, accessToken, tempDir);
+            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, ACCESS_TOKEN, tempDir);
             JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList());
             assertNotNull(serverConfig);
             assertEquals(serverConfig.getAccessToken(), accessToken);


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

will merge only when it update the repo
https://github.com/eyalk007/ide-plugins-common/pull/2
works on mine for now
