### PR TITLE
Add support for configuring environment variables in JfrogCliDriver

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -33,19 +33,20 @@ public class JfrogCliDriver {
     private static final ObjectMapper jsonReader = createMapper();
     private final Log log;
     private final String path;
-
+    private Map<String, String> env;
     @Getter
     private String jfrogExec = "jf";
 
     @SuppressWarnings("unused")
-    public JfrogCliDriver(Log log) {
-        this("", log);
+    public JfrogCliDriver(Map<String, String> env, Log log) {
+        this(env, "", log);
     }
 
-    public JfrogCliDriver(String path, Log log) {
+    public JfrogCliDriver(Map<String, String> env, String path, Log log) {
         if (SystemUtils.IS_OS_WINDOWS) {
             this.jfrogExec += ".exe";
         }
+        this.env = env;
         this.path = path;
         this.log = log;
     }
@@ -57,7 +58,7 @@ public class JfrogCliDriver {
 
     @SuppressWarnings("unused")
     public JfrogCliServerConfig getServerConfig() throws IOException {
-        return getServerConfig(Paths.get(".").toAbsolutePath().normalize().toFile(), Collections.emptyList(), null);
+        return getServerConfig(Paths.get(".").toAbsolutePath().normalize().toFile(), Collections.emptyList(), env);
     }
 
     public JfrogCliServerConfig getServerConfig(File workingDirectory, List<String> extraArgs, Map<String, String> envVars) throws IOException {
@@ -84,7 +85,7 @@ public class JfrogCliDriver {
     public String runVersion(File workingDirectory) {
         String versionOutput = null;
         try {
-            versionOutput = runCommand(workingDirectory, null, new String[]{"--version"}, Collections.emptyList()).getRes();
+            versionOutput = runCommand(workingDirectory, env, new String[]{"--version"}, Collections.emptyList()).getRes();
         } catch (IOException | InterruptedException e) {
             log.error("Failed to get CLI version. Reason: " + e.getMessage());
         }

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -100,7 +100,9 @@ public class JfrogCliDriver {
     public CommandResults runCommand(File workingDirectory, Map<String, String> commandEnvVars, String[] args, List<String> extraArgs, Log logger)
             throws IOException, InterruptedException {
         List<String> finalArgs = Stream.concat(Arrays.stream(args), extraArgs.stream()).collect(Collectors.toList());
-        Map<String, String> combinedEnvVars = mergeEnvVarsMaps(env, commandEnvVars);
+        Map<String, String> combinedEnvVars = new HashMap<>();
+        Optional.ofNullable(env).ifPresent(combinedEnvVars::putAll);
+        Optional.ofNullable(commandEnvVars).ifPresent(combinedEnvVars::putAll);
         CommandExecutor commandExecutor = new CommandExecutor(Paths.get(path, this.jfrogExec).toString(), combinedEnvVars);
         CommandResults commandResults = commandExecutor.exeCommand(workingDirectory, finalArgs, null, logger);
         if (!commandResults.isOk()) {
@@ -205,17 +207,5 @@ public class JfrogCliDriver {
         }
 
         return null;
-    }
-
-    private Map<String, String> mergeEnvVarsMaps(Map<String, String> envVars, Map<String, String> additionalEnvVars) {
-        Map<String, String> combinedEnvVars = new HashMap<>();
-        if (envVars != null) {
-            combinedEnvVars.putAll(envVars);
-            if (additionalEnvVars != null){
-                combinedEnvVars.putAll(additionalEnvVars);
-            }
-        }
-
-        return combinedEnvVars;
     }
 }

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.client.Version;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
@@ -32,22 +31,22 @@ import static com.jfrog.ide.common.utils.Utils.getOSAndArc;
 public class JfrogCliDriver {
     private static final String JFROG_CLI_RELEASES_URL = "https://releases.jfrog.io/artifactory";
     private static final ObjectMapper jsonReader = createMapper();
-    private final CommandExecutor commandExecutor;
     private final Log log;
+    private final String path;
 
     @Getter
     private String jfrogExec = "jf";
 
     @SuppressWarnings("unused")
-    public JfrogCliDriver(Map<String, String> env, Log log) {
-        this(env, "", log);
+    public JfrogCliDriver(Log log) {
+        this("", log);
     }
 
-    public JfrogCliDriver(Map<String, String> env, String path, Log log) {
+    public JfrogCliDriver(String path, Log log) {
         if (SystemUtils.IS_OS_WINDOWS) {
             this.jfrogExec += ".exe";
         }
-        this.commandExecutor = new CommandExecutor(Paths.get(path, this.jfrogExec).toString(), env);
+        this.path = path;
         this.log = log;
     }
 
@@ -58,16 +57,16 @@ public class JfrogCliDriver {
 
     @SuppressWarnings("unused")
     public JfrogCliServerConfig getServerConfig() throws IOException {
-        return getServerConfig(Paths.get(".").toAbsolutePath().normalize().toFile(), Collections.emptyList());
+        return getServerConfig(Paths.get(".").toAbsolutePath().normalize().toFile(), Collections.emptyList(), null);
     }
 
-    public JfrogCliServerConfig getServerConfig(File workingDirectory, List<String> extraArgs) throws IOException {
+    public JfrogCliServerConfig getServerConfig(File workingDirectory, List<String> extraArgs, Map<String, String> envVars) throws IOException {
         List<String> args = new ArrayList<>();
         args.add("config");
         args.add("export");
         args.addAll(extraArgs);
         try {
-            CommandResults commandResults = commandExecutor.exeCommand(workingDirectory, args, null, null);
+            CommandResults commandResults = runCommand(workingDirectory, envVars, args.toArray(new String[0]), Collections.emptyList(), log);
             String res = commandResults.getRes();
             if (StringUtils.isBlank(res) || !commandResults.isOk()) {
                 throw new IOException(commandResults.getErr());
@@ -85,7 +84,7 @@ public class JfrogCliDriver {
     public String runVersion(File workingDirectory) {
         String versionOutput = null;
         try {
-            versionOutput = runCommand(workingDirectory, new String[]{"--version"}, Collections.emptyList()).getRes();
+            versionOutput = runCommand(workingDirectory, null, new String[]{"--version"}, Collections.emptyList()).getRes();
         } catch (IOException | InterruptedException e) {
             log.error("Failed to get CLI version. Reason: " + e.getMessage());
         }
@@ -93,14 +92,15 @@ public class JfrogCliDriver {
         return versionOutput;
     }
 
-    private CommandResults runCommand(File workingDirectory, String[] args, List<String> extraArgs) throws IOException,
+    private CommandResults runCommand(File workingDirectory, Map<String, String> envVars, String[] args, List<String> extraArgs) throws IOException,
             InterruptedException {
-        return runCommand(workingDirectory, args, extraArgs, null);
+        return runCommand(workingDirectory, envVars, args, extraArgs, null);
     }
 
-    public CommandResults runCommand(File workingDirectory, String[] args, List<String> extraArgs, Log logger)
+    public CommandResults runCommand(File workingDirectory, Map<String, String> envVars, String[] args, List<String> extraArgs, Log logger)
             throws IOException, InterruptedException {
         List<String> finalArgs = Stream.concat(Arrays.stream(args), extraArgs.stream()).collect(Collectors.toList());
+        CommandExecutor commandExecutor = new CommandExecutor(Paths.get(path, this.jfrogExec).toString(), envVars);
         CommandResults commandResults = commandExecutor.exeCommand(workingDirectory, finalArgs, null, logger);
         if (!commandResults.isOk()) {
             throw new IOException(commandResults.getErr() + commandResults.getRes());
@@ -148,7 +148,7 @@ public class JfrogCliDriver {
         }
     }
 
-    public void addCliServerConfig(String xrayUrl, String artifactoryUrl, String cliServerId, String user, String password, String accessToken, File workingDirectory) throws Exception {
+    public void addCliServerConfig(String xrayUrl, String artifactoryUrl, String cliServerId, String user, String password, String accessToken, File workingDirectory, Map<String, String> envVars) throws Exception {
         List<String> args = new ArrayList<>();
         args.add("config");
         args.add("add");
@@ -167,7 +167,7 @@ public class JfrogCliDriver {
         }
 
         try {
-            runCommand(workingDirectory, args.toArray(new String[0]), Collections.emptyList(), log);
+            runCommand(workingDirectory, envVars, args.toArray(new String[0]), Collections.emptyList(), log);
             log.info("JFrog CLI server has been configured successfully");
         } catch (IOException | InterruptedException e) {
             log.error("Failed to configure JFrog CLI server. Reason: " + e.getMessage(), e);
@@ -175,7 +175,7 @@ public class JfrogCliDriver {
         }
     }
 
-    public CommandResults runCliAudit(File workingDirectory, List<String> scannedDirectories, String serverId, List<String> extraArgs) throws Exception {
+    public CommandResults runCliAudit(File workingDirectory, List<String> scannedDirectories, String serverId, List<String> extraArgs, Map<String, String> envVars) throws Exception {
         List<String> args = new ArrayList<>();
         args.add("audit");
         if (scannedDirectories != null && !scannedDirectories.isEmpty()) {
@@ -185,7 +185,7 @@ public class JfrogCliDriver {
         args.add("--server-id=" + serverId);
         args.add("--format=sarif");
         try {
-            return runCommand(workingDirectory, args.toArray(new String[0]), extraArgs != null ? extraArgs : Collections.emptyList(), log);
+            return runCommand(workingDirectory, envVars, args.toArray(new String[0]), extraArgs != null ? extraArgs : Collections.emptyList(), log);
         } catch (IOException | InterruptedException e) {
             throw new Exception("Failed to run JF audit. Reason: " + e.getMessage(), e);
         }

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -2,7 +2,6 @@ package com.jfrog.ide.common.configuration;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.NullLog;
-import org.jfrog.build.client.Version;
 import org.jfrog.build.extractor.executor.CommandResults;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -76,7 +75,7 @@ public class JfrogCliDriverTest {
             fail(e.getMessage(), e);
         }
         testEnv.put("JFROG_CLI_HOME_DIR", tempDir.getAbsolutePath());
-        jfrogCliDriver = new JfrogCliDriver(tempDir.getAbsolutePath() + File.separator, new NullLog());
+        jfrogCliDriver = new JfrogCliDriver(testEnv, tempDir.getAbsolutePath() + File.separator, new NullLog());
     }
 
     private void getCli(File execDir) throws IOException, InterruptedException {
@@ -117,7 +116,7 @@ public class JfrogCliDriverTest {
         // Assert the new downloaded cli version is compatible with the required version
         String newJfrogCliVersion = jfrogCliDriver.runVersion(destinationFolderFile);
 
-        assertTrue(newJfrogCliVersion.contains(jfrogCliVersion.toString()));
+        assertTrue(newJfrogCliVersion.contains(jfrogCliVersion));
         assertNotEquals(currentCliVersion, newJfrogCliVersion);
     }
 

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -45,7 +45,7 @@ public class JfrogCliDriverTest {
     @Test()
     private void cliExportTest() {
         try {
-            JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList());
+            JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList(), testEnv);
             assertEquals(serverConfig.getUsername(), USER_NAME);
             assertEquals(serverConfig.getPassword(), PASSWORD);
             assertEquals(serverConfig.getUrl(), SERVER_URL);
@@ -61,7 +61,7 @@ public class JfrogCliDriverTest {
             configJfrogCli();
             testServerId = createServerId();
             String[] serverConfigCmdArgs = {"config", "add", testServerId, "--user=" + USER_NAME, "--password=" + PASSWORD, "--url=" + SERVER_URL, "--interactive=false", "--enc-password=false"};
-            jfrogCliDriver.runCommand(tempDir, serverConfigCmdArgs, Collections.emptyList(), new NullLog());
+            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), new NullLog());
         } catch (IOException | InterruptedException e) {
             fail(e.getMessage(), e);
         }
@@ -76,7 +76,7 @@ public class JfrogCliDriverTest {
             fail(e.getMessage(), e);
         }
         testEnv.put("JFROG_CLI_HOME_DIR", tempDir.getAbsolutePath());
-        jfrogCliDriver = new JfrogCliDriver(testEnv, tempDir.getAbsolutePath() + File.separator, new NullLog());
+        jfrogCliDriver = new JfrogCliDriver(tempDir.getAbsolutePath() + File.separator, new NullLog());
     }
 
     private void getCli(File execDir) throws IOException, InterruptedException {
@@ -124,8 +124,8 @@ public class JfrogCliDriverTest {
     @Test
     public void testAddCliServerConfig_withUsernameAndPassword() {
         try {
-            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, USER_NAME, PASSWORD, null, tempDir);
-            JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList());
+            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, USER_NAME, PASSWORD, null, tempDir, testEnv);
+            JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList(), testEnv);
             assertNotNull(serverConfig);
             assertEquals(serverConfig.getUsername(), USER_NAME);
             assertEquals(serverConfig.getPassword(), PASSWORD);
@@ -139,8 +139,8 @@ public class JfrogCliDriverTest {
     @Test
     public void testAddCliServerConfig_withAccessToken() {
         try {
-            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, ACCESS_TOKEN, tempDir);
-            JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList());
+            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, ACCESS_TOKEN, tempDir, testEnv);
+            JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList(), testEnv);
             assertNotNull(serverConfig);
             assertEquals(serverConfig.getAccessToken(), ACCESS_TOKEN);
             assertEquals(serverConfig.getArtifactoryUrl(), ARTIFACTORY_URL);
@@ -156,9 +156,7 @@ public class JfrogCliDriverTest {
         try {
             Path exampleProjectsFolder = Path.of("src/test/resources/example-projects/npm");
             CommandResults response = jfrogCliDriver.runCliAudit(exampleProjectsFolder.toFile(),
-                    singletonList(projectToCheck),
-                    testServerId,
-                    null);
+                    singletonList(projectToCheck), testServerId, null, testEnv);
             //TODO: check real values after the sarif parser is added
             assertEquals(response.getExitValue(),0);
         } catch (Exception e) {
@@ -172,9 +170,7 @@ public class JfrogCliDriverTest {
         try {
             Path exampleProjectsFolder = Path.of("src/test/resources/example-projects/maven-example");
             CommandResults response = jfrogCliDriver.runCliAudit(exampleProjectsFolder.toFile(),
-                    projectsToCheck,
-                    testServerId,
-                    null);
+                    projectsToCheck, testServerId, null, testEnv);
             //TODO: check real values after the sarif parser is added
             assertEquals(response.getExitValue(), 0);
         } catch (Exception e) {
@@ -190,7 +186,7 @@ public class JfrogCliDriverTest {
     public void cleanUp() {
         try {
             String[] serverConfigCmdArgs = {"config", "remove", testServerId, "--quiet"};
-            jfrogCliDriver.runCommand(tempDir, serverConfigCmdArgs, Collections.emptyList(), new NullLog());
+            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), new NullLog());
         } catch (IOException | InterruptedException e) {
             fail(e.getMessage(), e);
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added support for configuring environment variables for each command executed by the JfrogCliDriver.