### PR TITLE
Bug fix in config command - logging credentials

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -151,7 +151,7 @@ public class JfrogCliDriver {
         }
     }
 
-    public void addCliServerConfig(String xrayUrl, String artifactoryUrl, String cliServerId, String user, String password, String accessToken, File workingDirectory, Map<String, String> envVars) throws Exception {
+    public CommandResults addCliServerConfig(String xrayUrl, String artifactoryUrl, String cliServerId, String user, String password, String accessToken, File workingDirectory, Map<String, String> envVars) throws Exception {
         List<String> args = new ArrayList<>();
         args.add("config");
         args.add("add");
@@ -170,11 +170,10 @@ public class JfrogCliDriver {
         }
 
         try {
-            runCommand(workingDirectory, envVars, args.toArray(new String[0]), Collections.emptyList(), log);
-            log.info("JFrog CLI server has been configured successfully");
+            // run the config command without log in order to avoid printing of credentials
+            return runCommand(workingDirectory, envVars, args.toArray(new String[0]), Collections.emptyList());
         } catch (IOException | InterruptedException e) {
-            log.error("Failed to configure JFrog CLI server. Reason: " + e.getMessage(), e);
-                throw new Exception("Failed to configure JFrog CLI server. Reason: " + e.getMessage(), e);
+            throw new Exception("Failed to configure JFrog CLI server. Reason: " + e.getMessage(), e);
         }
     }
 

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -123,8 +123,10 @@ public class JfrogCliDriverTest {
     @Test
     public void testAddCliServerConfig_withUsernameAndPassword() {
         try {
-            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, USER_NAME, PASSWORD, null, tempDir, testEnv);
+            CommandResults response = jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, USER_NAME, PASSWORD, null, tempDir, testEnv);
             JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList(), testEnv);
+            assertTrue(response.isOk());
+            assertTrue(response.getErr().isBlank());
             assertNotNull(serverConfig);
             assertEquals(serverConfig.getUsername(), USER_NAME);
             assertEquals(serverConfig.getPassword(), PASSWORD);
@@ -138,12 +140,28 @@ public class JfrogCliDriverTest {
     @Test
     public void testAddCliServerConfig_withAccessToken() {
         try {
-            jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, ACCESS_TOKEN, tempDir, testEnv);
+            CommandResults response = jfrogCliDriver.addCliServerConfig(XRAY_URL, ARTIFACTORY_URL, testServerId, null, null, ACCESS_TOKEN, tempDir, testEnv);
             JfrogCliServerConfig serverConfig = jfrogCliDriver.getServerConfig(tempDir, Collections.emptyList(), testEnv);
+            assertTrue(response.isOk());
+            assertTrue(response.getErr().isBlank());
             assertNotNull(serverConfig);
             assertEquals(serverConfig.getAccessToken(), ACCESS_TOKEN);
             assertEquals(serverConfig.getArtifactoryUrl(), ARTIFACTORY_URL);
             assertEquals(serverConfig.getXrayUrl(), XRAY_URL);
+        } catch (Exception e) {
+            fail(e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testAddServerConfig_withBadCredentials() {
+        try{
+            CommandResults response = jfrogCliDriver.addCliServerConfig("XRAY_URL", ARTIFACTORY_URL, testServerId, "user", "bad_password", "access_token", tempDir, testEnv);
+
+            // in case of an error the response result should be an empty string. The response error should contain the error message.
+            assertTrue(response.getRes().isBlank());
+            assertFalse(response.getErr().isBlank());
+
         } catch (Exception e) {
             fail(e.getMessage(), e);
         }

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -59,8 +59,9 @@ public class JfrogCliDriverTest {
         try {
             configJfrogCli();
             testServerId = createServerId();
-            String[] serverConfigCmdArgs = {"config", "add", testServerId, "--user=" + USER_NAME, "--password=" + PASSWORD, "--url=" + SERVER_URL, "--interactive=false", "--enc-password=false"};
-            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), new NullLog());
+            String[] serverConfigCmdArgs = {"config", "add", testServerId, "--url=" + SERVER_URL, "--interactive=false", "--enc-password=false"};
+            List<String> credentials = new ArrayList<>(Arrays.asList("--user=" + USER_NAME, "--password=" + PASSWORD));
+            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), credentials, new NullLog());
         } catch (IOException | InterruptedException e) {
             fail(e.getMessage(), e);
         }
@@ -203,7 +204,7 @@ public class JfrogCliDriverTest {
     public void cleanUp() {
         try {
             String[] serverConfigCmdArgs = {"config", "remove", testServerId, "--quiet"};
-            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), new NullLog());
+            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), null, new NullLog());
         } catch (IOException | InterruptedException e) {
             fail(e.getMessage(), e);
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Fixed a bug of logging the config command with credentials.
- Return the value of ResultCommand when calling addCliServerConfig.