### PR TITLE
Add support for presenting FileIssueNode title by calling toString method

### DIFF
--- a/src/main/java/com/jfrog/ide/common/nodes/FileIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/FileIssueNode.java
@@ -117,4 +117,9 @@ public class FileIssueNode extends IssueNode implements SubtitledTreeNode {
     public int hashCode() {
         return Objects.hash(title, reason, findingInfo, severity, reporterType, ruleId);
     }
+
+    @Override
+    public String toString() {
+        return title;
+    }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Implemented the toString() methos in FileIssueNode so it will return the title field (needed for Eclipse plugin TreeView presentation in the UI).