### PR TITLE
Add Info to SCA Issue Node and Improve Applicability Enum String Value

### DIFF
--- a/src/main/java/com/jfrog/ide/common/nodes/ScaIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ScaIssueNode.java
@@ -31,6 +31,7 @@ public class ScaIssueNode extends FileIssueNode {
     }
 
     private void parseComponentFromRuleId(String ruleId) {
+        // The ruleId format is expected to be "CVE_componentName_componentVersion". For example: "CVE-2021-22060_org.springframework:spring-core_5.0.3.RELEASE"
         String[] componentParts = ruleId.split("_");
         if (componentParts.length != 3) {
             return;

--- a/src/main/java/com/jfrog/ide/common/nodes/ScaIssueNode.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/ScaIssueNode.java
@@ -13,6 +13,8 @@ public class ScaIssueNode extends FileIssueNode {
     private Applicability applicability;
     private List<List<ImpactPath>> impactPaths;
     private String fixedVersions;
+    private String componentName;
+    private String componentVersion;
     // TODO: add isDirectDependency indication after implementing corresponding logic in cli-security
 
     // Empty constructor for deserialization
@@ -25,5 +27,15 @@ public class ScaIssueNode extends FileIssueNode {
         this.applicability = applicability;
         this.impactPaths = impactPaths;
         this.fixedVersions = fixedVersions;
+        parseComponentFromRuleId(ruleID);
+    }
+
+    private void parseComponentFromRuleId(String ruleId) {
+        String[] componentParts = ruleId.split("_");
+        if (componentParts.length != 3) {
+            return;
+        }
+        this.componentName = componentParts[1];
+        this.componentVersion = componentParts[2];
     }
 }

--- a/src/main/java/com/jfrog/ide/common/parse/Applicability.java
+++ b/src/main/java/com/jfrog/ide/common/parse/Applicability.java
@@ -4,11 +4,11 @@ import lombok.Getter;
 
 @Getter
 public enum Applicability {
-    APPLICABLE("applicable"),
-    NOT_APPLICABLE("not_applicable"),
-    UNDETERMINED("undetermined"),
-    NOT_COVERED("not_covered"),
-    MISSING_CONTEXT("missing_context");
+    APPLICABLE("Applicable"),
+    NOT_APPLICABLE("Not Applicable"),
+    UNDETERMINED("Undetermined"),
+    NOT_COVERED("Not Covered"),
+    MISSING_CONTEXT("Missing Context");
 
     private final String value;
 

--- a/src/main/java/com/jfrog/ide/common/parse/SarifParser.java
+++ b/src/main/java/com/jfrog/ide/common/parse/SarifParser.java
@@ -115,7 +115,7 @@ public class SarifParser {
         List<List<ImpactPath>> impactPaths = new ObjectMapper().convertValue(Objects.requireNonNull(rule.getProperties()).get(IMPACT_PATHS), new TypeReference<>() {
         });
         Severity severity = Severity.fromSarif(result.getLevel().toString());
-        String fullDescription = rule.getFullDescription() != null? rule.getFullDescription().getText() : null;
+        String fullDescription = rule.getHelp() != null ? rule.getHelp().getText() : null;
         String reason = result.getMessage().getText();
         String title = getTitleByScannerType(SourceCodeScanType.SCA, rule, result);
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added missing info for presenting SCA issues - component name and version.
- Use the help field instead of full description when parsing SCA results.
- Changed Applicability names to be more readable for usage in IDEs UI.  