### PR TITLE
Fix bug when downloading CLI

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -6,22 +6,23 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.client.Version;
 import org.jfrog.build.api.util.Log;
-import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.executor.CommandExecutor;
 import org.jfrog.build.extractor.executor.CommandResults;
-import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.jfrog.ide.common.utils.ArtifactoryConnectionUtils.createAnonymousAccessArtifactoryManagerBuilder;
 import static com.jfrog.ide.common.utils.Utils.*;
 
 /**
@@ -135,16 +136,19 @@ public class JfrogCliDriver {
 
         // download executable from releases and save it in 'destinationPath'
         try {
-            ServerConfig serverConfig = getServerConfig();
-            ArtifactoryManagerBuilder artifactoryManagerBuilder = createAnonymousAccessArtifactoryManagerBuilder(JFROG_CLI_RELEASES_URL, serverConfig.getProxyConfForTargetUrl(JFROG_CLI_RELEASES_URL), log);
-            ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build();
-            File cliExecutable = artifactoryManager.downloadToFile(fileLocationInReleases, destinationPath);
+//            ArtifactoryManagerBuilder artifactoryManagerBuilder = createAnonymousAccessArtifactoryManagerBuilder(JFROG_CLI_RELEASES_URL, serverConfig.getProxyConfForTargetUrl(JFROG_CLI_RELEASES_URL), log);
+//            ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build();
+//            File cliExecutable = artifactoryManager.downloadToFile(fileLocationInReleases, destinationPath);
             // setting the file as executable
-            if (!cliExecutable.setExecutable(true)) {
-                log.error(String.format("Failed to set downloaded CLI as executable. Path: %s", destinationPath));
-            } else {
-                log.debug(String.format("Downloaded CLI to %s. Permission te execute: %s", destinationPath, cliExecutable.canExecute()));
-            }
+            String finalUrl = JFROG_CLI_RELEASES_URL + "/" + fileLocationInReleases;
+            InputStream in = new URL(finalUrl).openStream();
+            Files.copy(in, basePath.resolve(jfrogExec), StandardCopyOption.REPLACE_EXISTING);
+
+//            if (!cliExecutable.setExecutable(true)) {
+//                log.error(String.format("Failed to set downloaded CLI as executable. Path: %s", destinationPath));
+//            } else {
+//                log.debug(String.format("Downloaded CLI to %s. Permission te execute: %s", destinationPath, cliExecutable.canExecute()));
+//            }
         } catch (IOException e) {
             log.error(String.format("Failed to download CLI from %s. Reason: %s", fileLocationInReleases, e.getMessage()), e);
             throw e;

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.jfrog.build.client.Version;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.executor.CommandExecutor;
 import org.jfrog.build.extractor.executor.CommandResults;
@@ -113,11 +112,10 @@ public class JfrogCliDriver {
         return commandResults;
     }
 
-    public void downloadCliIfNeeded(String destinationPath, String rawJfrogCliVersion) throws IOException {
-        Version jfrogCliVersion = new Version(rawJfrogCliVersion);
+    public void downloadCliIfNeeded(String destinationPath, String jfrogCliVersion) throws IOException {
         // verify installed cli version
         if (Files.exists(Paths.get(path, jfrogExec))){
-            Version cliVersion = extractVersionFromCliOutput(runVersion(new File(path)));
+            String cliVersion = extractVersionFromCliOutput(runVersion(new File(path)));
             log.debug("Local CLI version is: " + cliVersion);
             if (jfrogCliVersion.equals(cliVersion)) {
                 log.info("Local Jfrog CLI version has been verified and is compatible. Proceeding with its usage.");
@@ -132,8 +130,8 @@ public class JfrogCliDriver {
         }
     }
 
-    public void downloadCliFromReleases(Version cliVersion, String destinationFolder) throws IOException {
-        String[] urlParts = {"jfrog-cli/v2-jf", cliVersion.toString(), "jfrog-cli-" + getOSAndArc(), jfrogExec};
+    public void downloadCliFromReleases(String cliVersion, String destinationFolder) throws IOException {
+        String[] urlParts = {"jfrog-cli/v2-jf", cliVersion, "jfrog-cli-" + getOSAndArc(), jfrogExec};
         String fileLocationInReleases = String.join("/", urlParts);
         Path basePath = Paths.get(destinationFolder);
 
@@ -192,7 +190,7 @@ public class JfrogCliDriver {
         }
     }
 
-    private Version extractVersionFromCliOutput(String input) {
+    private String extractVersionFromCliOutput(String input) {
         if (input != null) {
             // define a pattern for the version format 'x.x.x'
             String regex = "\\b\\d+\\.\\d+\\.\\d+\\b";
@@ -200,7 +198,7 @@ public class JfrogCliDriver {
             Matcher matcher = pattern.matcher(input);
 
             if (matcher.find()) {
-                return new Version(matcher.group());
+                return matcher.group();
             }
         }
 

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -135,11 +135,10 @@ public class JfrogCliDriver {
         String fileLocationInReleases = String.join("/", urlParts);
         Path basePath = Paths.get(destinationFolder);
         String destinationPath = basePath.resolve(jfrogExec).toString();
+        String finalUrl = JFROG_CLI_RELEASES_URL + "/" + fileLocationInReleases;
 
         // download executable from releases and save it in 'destinationPath'
-        try {
-            String finalUrl = JFROG_CLI_RELEASES_URL + "/" + fileLocationInReleases;
-            InputStream in = new URL(finalUrl).openStream();
+        try (InputStream in = new URL(finalUrl).openStream()){
             Files.copy(in, basePath.resolve(jfrogExec), StandardCopyOption.REPLACE_EXISTING);
 
             // setting the file as executable

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -132,23 +132,13 @@ public class JfrogCliDriver {
         String[] urlParts = {"jfrog-cli/v2-jf", cliVersion.toString(), "jfrog-cli-" + getOSAndArc(), jfrogExec};
         String fileLocationInReleases = String.join("/", urlParts);
         Path basePath = Paths.get(destinationFolder);
-        String destinationPath = basePath.resolve(jfrogExec).toString();
 
         // download executable from releases and save it in 'destinationPath'
         try {
-//            ArtifactoryManagerBuilder artifactoryManagerBuilder = createAnonymousAccessArtifactoryManagerBuilder(JFROG_CLI_RELEASES_URL, serverConfig.getProxyConfForTargetUrl(JFROG_CLI_RELEASES_URL), log);
-//            ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build();
-//            File cliExecutable = artifactoryManager.downloadToFile(fileLocationInReleases, destinationPath);
             // setting the file as executable
             String finalUrl = JFROG_CLI_RELEASES_URL + "/" + fileLocationInReleases;
             InputStream in = new URL(finalUrl).openStream();
             Files.copy(in, basePath.resolve(jfrogExec), StandardCopyOption.REPLACE_EXISTING);
-
-//            if (!cliExecutable.setExecutable(true)) {
-//                log.error(String.format("Failed to set downloaded CLI as executable. Path: %s", destinationPath));
-//            } else {
-//                log.debug(String.format("Downloaded CLI to %s. Permission te execute: %s", destinationPath, cliExecutable.canExecute()));
-//            }
         } catch (IOException e) {
             log.error(String.format("Failed to download CLI from %s. Reason: %s", fileLocationInReleases, e.getMessage()), e);
             throw e;

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -134,13 +134,21 @@ public class JfrogCliDriver {
         String[] urlParts = {"jfrog-cli/v2-jf", cliVersion, "jfrog-cli-" + getOSAndArc(), jfrogExec};
         String fileLocationInReleases = String.join("/", urlParts);
         Path basePath = Paths.get(destinationFolder);
+        String destinationPath = basePath.resolve(jfrogExec).toString();
 
         // download executable from releases and save it in 'destinationPath'
         try {
-            // setting the file as executable
             String finalUrl = JFROG_CLI_RELEASES_URL + "/" + fileLocationInReleases;
             InputStream in = new URL(finalUrl).openStream();
             Files.copy(in, basePath.resolve(jfrogExec), StandardCopyOption.REPLACE_EXISTING);
+
+            // setting the file as executable
+            File cliExecutable = new File(String.valueOf(basePath.resolve(jfrogExec)));
+            if (!cliExecutable.setExecutable(true)) {
+                log.error(String.format("Failed to set downloaded CLI as executable. Path: %s", destinationPath));
+            } else {
+                log.debug(String.format("Downloaded CLI to %s. Permission te execute: %s", destinationPath, cliExecutable.canExecute()));
+            }
         } catch (IOException e) {
             throw new IOException(String.format("Failed to download CLI from %s. Reason: %s", fileLocationInReleases, e.getMessage()), e.getCause());
         }

--- a/src/main/java/com/jfrog/ide/common/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/common/utils/Utils.java
@@ -191,7 +191,7 @@ public class Utils {
             if (StringUtils.equalsAny(arch, "aarch64", "arm64")) {
                 return "mac-arm64";
             } else {
-                return "mac-amd64";
+                return "mac-386";
             }
         }
         // Linux
@@ -213,6 +213,8 @@ public class Utils {
                     return "linux-arm";
                 case "aarch64":
                     return "linux-arm64";
+                case "s390x":
+                    return "linux-s390x";
                 case "ppc64":
                 case "ppc64le":
                     return "linux-" + arch;

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -58,9 +58,9 @@ public class JfrogCliDriverTest {
     @BeforeMethod
     public void setUp(Object[] testArgs, Method method) {
         try {
-            boolean skip = TEST_NAME_TO_SKIP_CLI_DOWNLOAD.equals(method.getName());
-            configJfrogCli(skip);
-            if(!skip) {
+            boolean skipDownload = TEST_NAME_TO_SKIP_CLI_DOWNLOAD.equals(method.getName());
+            configJfrogCli(skipDownload);
+            if(!skipDownload) {
                 testServerId = createServerId();
                 String[] serverConfigCmdArgs = {"config", "add", testServerId, "--url=" + SERVER_URL, "--interactive=false", "--enc-password=false"};
                 List<String> credentials = new ArrayList<>(Arrays.asList("--user=" + USER_NAME, "--password=" + PASSWORD));
@@ -71,11 +71,11 @@ public class JfrogCliDriverTest {
         }
     }
 
-    private void configJfrogCli(Boolean skip) {
+    private void configJfrogCli(Boolean skipDownload) {
         try {
             tempDir = Files.createTempDirectory("ide-plugins-common-cli-test").toFile();
             tempDir.deleteOnExit();
-            if(!skip) {
+            if(!skipDownload) {
                 getCli(tempDir);
             }
         } catch (IOException | InterruptedException e) {
@@ -108,8 +108,7 @@ public class JfrogCliDriverTest {
 
     @Test
     void testDownloadCliIfNeeded_whenCliIsNotInstalled() throws IOException {
-        // We use hardcoded version because the setup method downloads the latest cli version which is greater than 2.73.0.
-        String jfrogCliVersion = "2.73.0";
+        String jfrogCliVersionToDownload = "2.73.0";
         String destinationFolder = tempDir.getAbsolutePath();
         File destinationFolderFile = new File(destinationFolder);
         Path jfrogCliPath = Paths.get(destinationFolder).resolve(jfrogCliDriver.getJfrogExec());
@@ -117,19 +116,19 @@ public class JfrogCliDriverTest {
         // Verify Jfrog cli executable file does not exist
         assertFalse(Files.exists(jfrogCliPath));
 
-        jfrogCliDriver.downloadCliIfNeeded(destinationFolder, jfrogCliVersion);
+        jfrogCliDriver.downloadCliIfNeeded(destinationFolder, jfrogCliVersionToDownload);
 
         // Assert the new downloaded cli version is compatible with the required version
         String newJfrogCliVersion = jfrogCliDriver.runVersion(destinationFolderFile);
 
         assertNotNull(newJfrogCliVersion);
-        assertTrue(newJfrogCliVersion.contains(jfrogCliVersion));
+        assertTrue(newJfrogCliVersion.contains(jfrogCliVersionToDownload));
     }
 
     @Test
     void testDownloadCliIfNeeded_whenCliIsInstalledButIncompatible() throws IOException {
         // We use hardcoded version because the setup method downloads the latest cli version which is greater than 2.73.0.
-        String jfrogCliVersion = "2.73.0";
+        String jfrogCliVersionToDownload = "2.73.0";
         String destinationFolder = tempDir.getAbsolutePath();
         File destinationFolderFile = new File(destinationFolder);
         Path jfrogCliPath = Paths.get(destinationFolder).resolve(jfrogCliDriver.getJfrogExec());
@@ -138,12 +137,12 @@ public class JfrogCliDriverTest {
         assertTrue(Files.exists(jfrogCliPath));
         String currentCliVersion = jfrogCliDriver.runVersion(destinationFolderFile);
 
-        jfrogCliDriver.downloadCliIfNeeded(destinationFolder, jfrogCliVersion);
+        jfrogCliDriver.downloadCliIfNeeded(destinationFolder, jfrogCliVersionToDownload);
 
         // Assert the new downloaded cli version is compatible with the required version
         String newJfrogCliVersion = jfrogCliDriver.runVersion(destinationFolderFile);
 
-        assertTrue(newJfrogCliVersion.contains(jfrogCliVersion));
+        assertTrue(newJfrogCliVersion.contains(jfrogCliVersionToDownload));
         assertNotEquals(currentCliVersion, newJfrogCliVersion);
     }
 

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -119,6 +119,7 @@ public class JfrogCliDriverTest {
         // Assert the new downloaded cli version is compatible with the required version
         String newJfrogCliVersion = jfrogCliDriver.runVersion(destinationFolderFile);
 
+        assertNotNull(newJfrogCliVersion);
         assertTrue(newJfrogCliVersion.contains(jfrogCliVersion));
     }
 

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -223,10 +223,12 @@ public class JfrogCliDriverTest {
     }
 
     @AfterMethod
-    public void cleanUp() {
+    public void cleanUp(Method method) {
         try {
-            String[] serverConfigCmdArgs = {"config", "remove", testServerId, "--quiet"};
-            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), null, new NullLog());
+            if (!TEST_NAME_TO_SKIP_CLI_DOWNLOAD.equals(method.getName())) {
+                String[] serverConfigCmdArgs = {"config", "remove", testServerId, "--quiet"};
+                jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), null, new NullLog());
+            }
         } catch (IOException | InterruptedException e) {
             fail(e.getMessage(), e);
         }

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -58,11 +58,14 @@ public class JfrogCliDriverTest {
     @BeforeMethod
     public void setUp(Object[] testArgs, Method method) {
         try {
-            configJfrogCli(TEST_NAME_TO_SKIP_CLI_DOWNLOAD.equals(method.getName()));
-            testServerId = createServerId();
-            String[] serverConfigCmdArgs = {"config", "add", testServerId, "--url=" + SERVER_URL, "--interactive=false", "--enc-password=false"};
-            List<String> credentials = new ArrayList<>(Arrays.asList("--user=" + USER_NAME, "--password=" + PASSWORD));
-            jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), credentials, new NullLog());
+            boolean skip = TEST_NAME_TO_SKIP_CLI_DOWNLOAD.equals(method.getName());
+            configJfrogCli(skip);
+            if(!skip) {
+                testServerId = createServerId();
+                String[] serverConfigCmdArgs = {"config", "add", testServerId, "--url=" + SERVER_URL, "--interactive=false", "--enc-password=false"};
+                List<String> credentials = new ArrayList<>(Arrays.asList("--user=" + USER_NAME, "--password=" + PASSWORD));
+                jfrogCliDriver.runCommand(tempDir, testEnv, serverConfigCmdArgs, Collections.emptyList(), credentials, new NullLog());
+            }
         } catch (IOException | InterruptedException e) {
             fail(e.getMessage(), e);
         }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Resolved an issue where the CLI download process did not verify the existence of the CLI executable in the destination folder. As a result, the version check would depend on the CLI version installed on the machine.
- Updated the download implementation to utilize URI, eliminating the need for server configuration.
- Fixed issue with MacOS architecture identification to ensure the correct CLI version is downloaded.