### PR TITLE
Add environment variable to the cliDriver for ignoring version warning in cli logs

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -45,6 +45,7 @@ public class JfrogCliDriver {
         if (SystemUtils.IS_OS_WINDOWS) {
             this.jfrogExec += ".exe";
         }
+        addDefaultEnvVars(env);
         this.env = env;
         this.path = path;
         this.log = log;
@@ -210,5 +211,12 @@ public class JfrogCliDriver {
         }
 
         return null;
+    }
+
+    private void addDefaultEnvVars(Map<String, String> env) {
+        if (env == null) {
+            return;
+        }
+        env.put("JFROG_CLI_AVOID_NEW_VERSION_WARNING", "true");
     }
 }

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -214,9 +214,8 @@ public class JfrogCliDriver {
     }
 
     private void addDefaultEnvVars(Map<String, String> env) {
-        if (env == null) {
-            return;
+        if (env != null) {
+            env.put("JFROG_CLI_AVOID_NEW_VERSION_WARNING", "true");
         }
-        env.put("JFROG_CLI_AVOID_NEW_VERSION_WARNING", "true");
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added the environment variable `JFROG_CLI_AVOID_NEW_VERSION_WARNING=true`  for ignoring the version warning in cli logs.