### PR TITLE
Added Common Objects for WebView Integration

### DIFF
--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactPath.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactPath.java
@@ -1,13 +1,8 @@
 package com.jfrog.ide.common.nodes.subentities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.jfrog.ide.common.webview.ImpactGraph;
-import com.jfrog.ide.common.webview.ImpactGraphNode;
 import lombok.Getter;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 
@@ -35,46 +30,5 @@ public class ImpactPath {
         if (o == null || getClass() != o.getClass()) return false;
         ImpactPath that = (ImpactPath) o;
         return Objects.equals(this.name, that.name) && Objects.equals(this.version, that.version);
-    }
-
-    /**
-     * Converts a list of impact paths to an ImpactGraph.
-     * Each path is a list of ImpactPath objects, representing a path from root to leaf.
-     * Node names are "name:version" (or just "name" if version is empty).
-     */
-    public static ImpactGraph toImpactGraph(List<List<ImpactPath>> impactPaths) {
-        // Use a dummy root node
-        Node root = new Node("root");
-        int maxDepth = 0;
-        for (List<ImpactPath> path : impactPaths) {
-            Node current = root;
-            int depth = 0;
-            for (ImpactPath ip : path) {
-                String nodeName = ip.getName() + (ip.getVersion() != null && !ip.getVersion().isEmpty() ? ":" + ip.getVersion() : "");
-                current = current.children.computeIfAbsent(nodeName, Node::new);
-                depth++;
-            }
-            if (depth > maxDepth) {
-                maxDepth = depth;
-            }
-        }
-        ImpactGraphNode rootGraphNode = toGraphNode(root);
-        // Set pathsLimit to the maximum depth found
-        return new ImpactGraph(rootGraphNode, maxDepth + 1); // +1 to include root
-    }
-
-    // Internal tree node for building
-    private static class Node {
-        String name;
-        Map<String, Node> children = new LinkedHashMap<>();
-        Node(String name) { this.name = name; }
-    }
-
-    // Convert internal Node tree to ImpactGraphNode tree
-    private static ImpactGraphNode toGraphNode(Node node) {
-        ImpactGraphNode[] children = node.children.values().stream()
-            .map(ImpactPath::toGraphNode)
-            .toArray(ImpactGraphNode[]::new);
-        return new ImpactGraphNode(node.name, children);
     }
 }

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactPath.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactPath.java
@@ -42,18 +42,25 @@ public class ImpactPath {
      * Each path is a list of ImpactPath objects, representing a path from root to leaf.
      * Node names are "name:version" (or just "name" if version is empty).
      */
-    public static ImpactGraph toImpactGraph(List<List<ImpactPath>> impactPaths, int pathsLimit) {
+    public static ImpactGraph toImpactGraph(List<List<ImpactPath>> impactPaths) {
         // Use a dummy root node
         Node root = new Node("root");
+        int maxDepth = 0;
         for (List<ImpactPath> path : impactPaths) {
             Node current = root;
+            int depth = 0;
             for (ImpactPath ip : path) {
                 String nodeName = ip.getName() + (ip.getVersion() != null && !ip.getVersion().isEmpty() ? ":" + ip.getVersion() : "");
                 current = current.children.computeIfAbsent(nodeName, Node::new);
+                depth++;
+            }
+            if (depth > maxDepth) {
+                maxDepth = depth;
             }
         }
         ImpactGraphNode rootGraphNode = toGraphNode(root);
-        return new ImpactGraph(rootGraphNode, pathsLimit);
+        // Set pathsLimit to the maximum depth found
+        return new ImpactGraph(rootGraphNode, maxDepth + 1); // +1 to include root
     }
 
     // Internal tree node for building

--- a/src/main/java/com/jfrog/ide/common/parse/Applicability.java
+++ b/src/main/java/com/jfrog/ide/common/parse/Applicability.java
@@ -26,6 +26,16 @@ public enum Applicability {
             default -> throw new IllegalArgumentException("'%s' applicability status not supported" + value);
         };
     }
+
+    public static String getWebviewIconName(Applicability applicability) {
+        return switch (applicability) {
+            case APPLICABLE -> "applicable";
+            case NOT_APPLICABLE -> "not_applicable";
+            case UNDETERMINED -> "undetermined";
+            case NOT_COVERED -> "not_covered";
+            case MISSING_CONTEXT -> "missing_context";
+        };
+    }
 }
 
 

--- a/src/main/java/com/jfrog/ide/common/webview/ApplicableDetails.java
+++ b/src/main/java/com/jfrog/ide/common/webview/ApplicableDetails.java
@@ -1,0 +1,16 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicableDetails {
+    private final boolean isApplicable;
+    private final Evidence[] evidence;
+    private final String searchTarget;
+
+    public ApplicableDetails(boolean isApplicable, Evidence[] evidence, String searchTarget) {
+        this.isApplicable = isApplicable;
+        this.evidence = evidence;
+        this.searchTarget = searchTarget;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/ApplicableDetails.java
+++ b/src/main/java/com/jfrog/ide/common/webview/ApplicableDetails.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 
 @Getter
 public class ApplicableDetails {
-    private final boolean isApplicable;
+    private final String applicability;
     private final Evidence[] evidence;
     private final String searchTarget;
 
-    public ApplicableDetails(boolean isApplicable, Evidence[] evidence, String searchTarget) {
-        this.isApplicable = isApplicable;
+    public ApplicableDetails(String applicability, Evidence[] evidence, String searchTarget) {
+        this.applicability = applicability;
         this.evidence = evidence;
         this.searchTarget = searchTarget;
     }

--- a/src/main/java/com/jfrog/ide/common/webview/Cve.java
+++ b/src/main/java/com/jfrog/ide/common/webview/Cve.java
@@ -1,0 +1,22 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class Cve {
+    private final String id;
+    private final String cvssV2Score;
+    private final String cvssV2Vector;
+    private final String cvssV3Score;
+    private final String cvssV3Vector;
+    private final ApplicableDetails applicableData;
+
+    public Cve(String id, String cvssV2Score, String cvssV2Vector, String cvssV3Score, String cvssV3Vector, ApplicableDetails applicableData) {
+        this.id = id;
+        this.cvssV2Score = cvssV2Score;
+        this.cvssV2Vector = cvssV2Vector;
+        this.cvssV3Score = cvssV3Score;
+        this.cvssV3Vector = cvssV3Vector;
+        this.applicableData = applicableData;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/DependencyPage.java
+++ b/src/main/java/com/jfrog/ide/common/webview/DependencyPage.java
@@ -1,0 +1,88 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+public class DependencyPage {
+    private String id;
+    private String component;
+    private String componentType;
+    private final String pageType = "DEPENDENCY";
+    private String version;
+    private String severity;
+    private License[] license;
+    private String summary;
+    private String[] fixedVersion;
+    private String[] infectedVersion;
+    private Reference[] references;
+    private Cve cve;
+    private ImpactGraph impactGraph;
+    private String[] watchName;
+    private String edited;
+    private ExtendedInformation extendedInformation;
+
+    public DependencyPage() {
+    }
+
+    public DependencyPage component(String component) {
+        this.component = component;
+        return this;
+    }
+
+    public DependencyPage id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public DependencyPage componentType(String componentType) {
+        this.componentType = componentType;
+        return this;
+    }
+
+    public DependencyPage version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    public DependencyPage severity(String severity) {
+        this.severity = severity;
+        return this;
+    }
+
+    public DependencyPage license(License[] license) {
+        this.license = license;
+        return this;
+    }
+
+    public DependencyPage summary(String summary) {
+        this.summary = summary;
+        return this;
+    }
+
+    public DependencyPage fixedVersion(String[] fixedVersion) {
+        this.fixedVersion = fixedVersion;
+        return this;
+    }
+
+    public DependencyPage infectedVersion(String[] infectedVersion) {
+        this.infectedVersion = infectedVersion;
+        return this;
+    }
+
+    public DependencyPage references(Reference[] references) {
+        this.references = references;
+        return this;
+    }
+
+    public DependencyPage cve(Cve cve) {
+        this.cve = cve;
+        return this;
+    }
+
+    public DependencyPage impactGraph(ImpactGraph impactGraph) {
+        this.impactGraph = impactGraph;
+        return this;
+    }
+}
+

--- a/src/main/java/com/jfrog/ide/common/webview/Evidence.java
+++ b/src/main/java/com/jfrog/ide/common/webview/Evidence.java
@@ -1,0 +1,16 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class Evidence {
+    private final String reason;
+    private final String filePathEvidence;
+    private final String codeEvidence;
+
+    public Evidence(String reason, String filePathEvidence, String codeEvidence) {
+        this.reason = reason;
+        this.filePathEvidence = filePathEvidence;
+        this.codeEvidence = codeEvidence;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/ExtendedInformation.java
+++ b/src/main/java/com/jfrog/ide/common/webview/ExtendedInformation.java
@@ -1,0 +1,20 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class ExtendedInformation {
+    private final String shortDescription;
+    private final String fullDescription;
+    private final String jfrogResearchSeverity;
+    private final String remediation;
+    private final JfrogResearchSeverityReason[] jfrogResearchSeverityReason;
+
+    public ExtendedInformation(String shortDescription, String fullDescription, String jfrogResearchSeverity, String remediation, JfrogResearchSeverityReason[] jfrogResearchSeverityReason) {
+        this.shortDescription = shortDescription;
+        this.fullDescription = fullDescription;
+        this.jfrogResearchSeverity = jfrogResearchSeverity;
+        this.remediation = remediation;
+        this.jfrogResearchSeverityReason = jfrogResearchSeverityReason;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/Finding.java
+++ b/src/main/java/com/jfrog/ide/common/webview/Finding.java
@@ -1,0 +1,23 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class Finding {
+    private final String does;
+    private final String happen;
+    private final String meaning;
+    private final String snippet;
+
+    public Finding(String happen, String meaning, String snippet, String does) {
+        this.happen = happen;
+        this.meaning = meaning;
+        this.snippet = snippet;
+        this.does = does;
+    }
+
+    public Finding(Finding other) {
+        this(other.happen, other.meaning, other.snippet, other.does);
+    }
+}
+

--- a/src/main/java/com/jfrog/ide/common/webview/ImpactGraph.java
+++ b/src/main/java/com/jfrog/ide/common/webview/ImpactGraph.java
@@ -1,0 +1,16 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class ImpactGraph {
+    private final ImpactGraphNode root;
+    private final int pathsLimit;
+
+    public ImpactGraph(ImpactGraphNode root, int pathsLimit) {
+        this.root = root;
+        this.pathsLimit = pathsLimit;
+    }
+}
+
+

--- a/src/main/java/com/jfrog/ide/common/webview/ImpactGraph.java
+++ b/src/main/java/com/jfrog/ide/common/webview/ImpactGraph.java
@@ -12,5 +12,3 @@ public class ImpactGraph {
         this.pathsLimit = pathsLimit;
     }
 }
-
-

--- a/src/main/java/com/jfrog/ide/common/webview/ImpactGraphNode.java
+++ b/src/main/java/com/jfrog/ide/common/webview/ImpactGraphNode.java
@@ -1,0 +1,14 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class ImpactGraphNode {
+    private final String name;
+    private final ImpactGraphNode[] children;
+
+    public ImpactGraphNode(String name, ImpactGraphNode[] children) {
+        this.name = name;
+        this.children = children;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/IssuePage.java
+++ b/src/main/java/com/jfrog/ide/common/webview/IssuePage.java
@@ -1,0 +1,67 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+public class IssuePage {
+    private String pageType;
+    private String header;
+    private String severity;
+    private String abbreviation;
+    private Location location;
+    private String description;
+    private Finding finding;
+
+    public IssuePage() {
+    }
+
+    public IssuePage(IssuePage other) {
+        if (other == null) {
+            return;
+        }
+        this.pageType = other.pageType;
+        this.header = other.header;
+        this.severity = other.severity;
+        this.abbreviation = other.abbreviation;
+        this.location = other.location != null ? new Location(other.location) : null;
+        this.description = other.description;
+        this.finding = other.finding != null ? new Finding(other.finding) : null;
+    }
+
+    public IssuePage header(String header) {
+        this.header = header;
+        return this;
+    }
+
+    public IssuePage severity(String severity) {
+        this.severity = severity;
+        return this;
+    }
+
+    public IssuePage abbreviation(String abbreviation) {
+        this.abbreviation = abbreviation;
+        return this;
+    }
+
+    public IssuePage location(Location location) {
+        this.location = location;
+        return this;
+    }
+
+    public IssuePage description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public IssuePage finding(Finding finding) {
+        this.finding = finding;
+        return this;
+    }
+
+    public IssuePage type(String type) {
+        this.pageType = type;
+        return this;
+    }
+}
+

--- a/src/main/java/com/jfrog/ide/common/webview/JfrogResearchSeverityReason.java
+++ b/src/main/java/com/jfrog/ide/common/webview/JfrogResearchSeverityReason.java
@@ -1,0 +1,16 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class JfrogResearchSeverityReason {
+    private final String name;
+    private final String description;
+    private final boolean isPositive;
+
+    public JfrogResearchSeverityReason(String name, String description, boolean isPositive) {
+        this.name = name;
+        this.description = description;
+        this.isPositive = isPositive;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/License.java
+++ b/src/main/java/com/jfrog/ide/common/webview/License.java
@@ -1,0 +1,14 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class License {
+    private final String name;
+    private final String link;
+
+    public License(String name, String link) {
+        this.name = name;
+        this.link = link;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/Location.java
+++ b/src/main/java/com/jfrog/ide/common/webview/Location.java
@@ -1,0 +1,42 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Setter
+@Getter
+public class Location implements Serializable {
+    private String file;
+    private String fileName;
+    private String snippet;
+    private int startRow;
+    private int startColumn;
+    private int endRow;
+    private int endColumn;
+
+    public Location() {
+        this.file = "";
+        this.fileName = "";
+        this.snippet = "";
+        this.startRow = 0;
+        this.startColumn = 0;
+        this.endRow = 0;
+        this.endColumn = 0;
+    }
+
+    public Location(String file, String fileName, int startRow, int startColumn, int endRow, int endColumn, String snippet) {
+        this.file = file;
+        this.fileName = fileName;
+        this.snippet = snippet;
+        this.startRow = startRow;
+        this.startColumn = startColumn;
+        this.endRow = endRow;
+        this.endColumn = endColumn;
+    }
+
+    public Location(Location other) {
+        this(other.file, other.fileName, other.startRow, other.startColumn, other.endRow, other.endColumn, other.snippet);
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/Reference.java
+++ b/src/main/java/com/jfrog/ide/common/webview/Reference.java
@@ -1,0 +1,14 @@
+package com.jfrog.ide.common.webview;
+
+import lombok.Getter;
+
+@Getter
+public class Reference {
+    private final String url;
+    private final String text;
+
+    public Reference(String url, String text) {
+        this.url = url;
+        this.text = text;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/SastIssuePage.java
+++ b/src/main/java/com/jfrog/ide/common/webview/SastIssuePage.java
@@ -1,0 +1,29 @@
+package com.jfrog.ide.common.webview;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+public class SastIssuePage extends IssuePage {
+    @JsonProperty("analysisStep")
+    private Location[] analysisSteps;
+    private String ruleId;
+
+    public SastIssuePage() {
+    }
+
+    public SastIssuePage(IssuePage issuePage) {
+        super(issuePage);
+    }
+
+    public SastIssuePage setAnalysisSteps(Location[] analysisSteps) {
+        this.analysisSteps = analysisSteps;
+        return this;
+    }
+
+    public SastIssuePage setRuleID(String ruleID) {
+        this.ruleId = ruleID;
+        return this;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/events/Event.java
+++ b/src/main/java/com/jfrog/ide/common/webview/events/Event.java
@@ -1,0 +1,23 @@
+package com.jfrog.ide.common.webview.events;
+
+import java.io.Serializable;
+
+/**
+ * The Event class is an abstract model designed to facilitate communication between the IDE and the Webview.
+ * It serves as the base class for various event types that can be transmitted between these components.
+ */
+public abstract class Event implements Serializable {
+    private Object data;
+
+    public Event(Object data) {
+        this.data = data;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/jfrog/ide/common/webview/events/IdeEvent.java
+++ b/src/main/java/com/jfrog/ide/common/webview/events/IdeEvent.java
@@ -1,0 +1,22 @@
+package com.jfrog.ide.common.webview.events;
+
+/**
+ * Represents an IDE-specific event that can be sent from the Webview to the IDE.
+ */
+public class IdeEvent extends Event {
+    private Type type;
+
+    public IdeEvent() {
+        super(null);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public enum Type {JUMP_TO_CODE, LOGIN, WEBVIEW_LOADED}
+}

--- a/src/main/java/com/jfrog/ide/common/webview/events/WebviewEvent.java
+++ b/src/main/java/com/jfrog/ide/common/webview/events/WebviewEvent.java
@@ -1,0 +1,28 @@
+package com.jfrog.ide.common.webview.events;
+
+/**
+ * Represents a Webview-specific event that can be sent from the IDE to the Webview.
+ */
+public class WebviewEvent extends Event {
+    private Type type;
+
+    @SuppressWarnings("unused")
+    public WebviewEvent() {
+        super(null);
+    }
+
+    public WebviewEvent(Type type, Object data) {
+        super(data);
+        this.type = type;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public enum Type {SET_EMITTER, SHOW_PAGE}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added common objects used by IDEA and Eclipse plugins for WebView integration and data exchange.
- Added a conversion method from Applicability to webview icon names to ensure compliance between WebView and the data in the ScaIssueNode.