### PR TITLE
Add support for exclude pattern in cli driver

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/AuditConfig.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/AuditConfig.java
@@ -11,14 +11,12 @@ public class AuditConfig {
     private final List<String> scannedDirectories;
     private final String serverId;
     private final List<String> excludedPattern;
-    private final List<String> extraArgs;
     private final Map<String, String> envVars;
 
     private AuditConfig(Builder builder) {
         this.scannedDirectories = builder.scannedDirectories;
         this.serverId = builder.serverId;
         this.excludedPattern = builder.excludedPattern;
-        this.extraArgs = builder.extraArgs;
         this.envVars = builder.envVars;
     }
 
@@ -26,7 +24,6 @@ public class AuditConfig {
         private List<String> scannedDirectories;
         private String serverId;
         private List<String> excludedPattern;
-        private List<String> extraArgs;
         private Map<String, String> envVars;
 
         public Builder serverId(String serverId) {
@@ -41,11 +38,6 @@ public class AuditConfig {
 
         public Builder excludedPattern(List<String> excludedPattern) {
             this.excludedPattern = excludedPattern;
-            return this;
-        }
-
-        public Builder extraArgs(List<String> extraArgs) {
-            this.extraArgs = extraArgs;
             return this;
         }
 

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -182,11 +182,10 @@ public class JfrogCliDriver {
         }
     }
 
-    public CommandResults runCliAudit(File workingDirectory, List<String> scannedDirectories, String serverId, List<String> extraArgs, Map<String, String> envVars) throws Exception {
+    public CommandResults runCliAudit(File workingDirectory, List<String> scannedDirectories, String serverId, Map<String, String> envVars) throws Exception {
         AuditConfig config = new AuditConfig.Builder()
                 .scannedDirectories(scannedDirectories)
                 .serverId(serverId)
-                .extraArgs(extraArgs)
                 .envVars(envVars)
                 .build();
         return runCliAudit(workingDirectory, config);
@@ -212,8 +211,7 @@ public class JfrogCliDriver {
         }
 
         try {
-            return runCommand(workingDirectory, config.getEnvVars(), args.toArray(new String[0]),
-                    config.getExtraArgs() != null ? config.getExtraArgs() : Collections.emptyList(), null, log);
+            return runCommand(workingDirectory, config.getEnvVars(), args.toArray(new String[0]), Collections.emptyList(), null, log);
         } catch (IOException | InterruptedException e) {
             throw new Exception("Failed to run JF audit. Reason: " + e.getMessage(), e);
         }

--- a/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
+++ b/src/test/java/com/jfrog/ide/common/configuration/JfrogCliDriverTest.java
@@ -206,7 +206,7 @@ public class JfrogCliDriverTest {
         try {
             Path exampleProjectsFolder = Path.of("src/test/resources/example-projects/npm");
             CommandResults response = jfrogCliDriver.runCliAudit(exampleProjectsFolder.toFile(),
-                    null, testServerId, null, testEnv);
+                    null, testServerId, testEnv);
             assertEquals(response.getExitValue(),0);
             logger.info("Audit debug logs: \n" + response.getErr());
             logger.info("Audit response: \n" + response.getRes());
@@ -231,7 +231,7 @@ public class JfrogCliDriverTest {
         try {
             Path exampleProjectsFolder = Path.of("src/test/resources/example-projects/maven-example");
             CommandResults response = jfrogCliDriver.runCliAudit(exampleProjectsFolder.toFile(),
-                    projectsToCheck, testServerId, null, testEnv);
+                    projectsToCheck, testServerId, testEnv);
             assertEquals(response.getExitValue(), 0);
             logger.info("Audit debug logs: \n" + response.getErr());
             logger.info("Audit response: \n" + response.getRes());
@@ -262,7 +262,6 @@ public class JfrogCliDriverTest {
                     .serverId(testServerId)
                     .excludedPattern(new ArrayList<>(List.of("*multi3*")))
                     .serverId(testServerId)
-                    .extraArgs(null)
                     .envVars(testEnv)
                     .build();
             CommandResults response = jfrogCliDriver.runCliAudit(exampleProjectsFolder.toFile(), config);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added support for using the `--exclusions` flag when running audit scan via CliDriver class.
- Added AuditConfig utility class to centralize audit scan parameters and make configuration more generic, flexible, and maintainable.
- Added debug logs output for JfrogCliDriver audit tests.