### PR TITLE
Add support for watches in audit scan in JfrogCliDriver

### DIFF
--- a/src/main/java/com/jfrog/ide/common/configuration/AuditConfig.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/AuditConfig.java
@@ -12,12 +12,14 @@ public class AuditConfig {
     private final String serverId;
     private final List<String> excludedPattern;
     private final Map<String, String> envVars;
+    private final List<String> watches;
 
     private AuditConfig(Builder builder) {
         this.scannedDirectories = builder.scannedDirectories;
         this.serverId = builder.serverId;
         this.excludedPattern = builder.excludedPattern;
         this.envVars = builder.envVars;
+        this.watches = builder.watches;
     }
 
     public static class Builder {
@@ -25,6 +27,7 @@ public class AuditConfig {
         private String serverId;
         private List<String> excludedPattern;
         private Map<String, String> envVars;
+        private List<String> watches;
 
         public Builder serverId(String serverId) {
             this.serverId = serverId;
@@ -48,6 +51,11 @@ public class AuditConfig {
 
         public AuditConfig build() {
             return new AuditConfig(this);
+        }
+
+        public Builder watches(List<String> watches) {
+            this.watches = watches;
+            return this;
         }
     }
 

--- a/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
+++ b/src/main/java/com/jfrog/ide/common/configuration/JfrogCliDriver.java
@@ -210,6 +210,11 @@ public class JfrogCliDriver {
             args.add("--exclusions=" + quoteArgumentForUnix(excludedPatterns));
         }
 
+        if (config.getWatches() != null && !config.getWatches().isEmpty()) {
+            String watches = String.join(",", config.getWatches());
+            args.add("--watches=" + quoteArgumentForUnix(watches));
+        }
+
         try {
             return runCommand(workingDirectory, config.getEnvVars(), args.toArray(new String[0]), Collections.emptyList(), null, log);
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/ide-plugins-common/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Introduced watch support in audit scans by extending AuditConfig and updating JfrogCliDriver integration.