### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 out
 .idea
 .gradle
+bin

--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,16 @@ repositories {
 }
 
 def buildInfoVersion = '2.43.6'
+// Updated to 2.17.3 for security fixes - compatible with Java 8+
+def jacksonVersion = '2.17.3'
+
 dependencies {
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-go', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-client', version: buildInfoVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     implementation(group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13') {
         exclude group: 'commons-codec', module: 'commons-codec'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.41.13'
+def buildInfoVersion = '2.43.6'
 dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor-npm', version: buildInfoVersion
@@ -42,7 +42,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.13'
-    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.0.1'
+    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.2.1'
     implementation group: 'commons-io', name: 'commons-io', version: '2.20.0'
     implementation(group: 'com.opencsv', name: 'opencsv', version: '5.11.1') {
         exclude group: 'common-collections', module: 'commons-collections'

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.13'
-    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.2.1'
+    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.0.1'
     implementation group: 'commons-io', name: 'commons-io', version: '2.20.0'
     implementation(group: 'com.opencsv', name: 'opencsv', version: '5.11.1') {
         exclude group: 'common-collections', module: 'commons-collections'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.13'
-    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.0.1'
+    implementation group: 'com.jfrog', name: 'gradle-dep-tree', version: '3.2.1'
     implementation group: 'commons-io', name: 'commons-io', version: '2.20.0'
     implementation(group: 'com.opencsv', name: 'opencsv', version: '5.11.1') {
         exclude group: 'common-collections', module: 'commons-collections'

--- a/src/main/java/com/jfrog/ide/common/gradle/GradleDriver.java
+++ b/src/main/java/com/jfrog/ide/common/gradle/GradleDriver.java
@@ -67,7 +67,6 @@ public class GradleDriver {
         Path initScript = Files.createTempFile("init-script", encodedPath);
         logger.debug("dependencies.gradle init script path: " + initScript);
         Path outputFile = Files.createTempFile("gradle-deps-tree", "");
-        Path gradleUserHome = Files.createTempDirectory("jfrog-gradle-user-home-");
         try (InputStream gradleInitScript = getClass().getResourceAsStream("/gradle-dep-tree.gradle")) {
             if (gradleInitScript == null) {
                 throw new IOException("Couldn't find dependencies.gradle init script.");
@@ -76,13 +75,8 @@ public class GradleDriver {
             // Copy init script to the temp file
             Files.copy(gradleInitScript, initScript, StandardCopyOption.REPLACE_EXISTING);
 
-            // Isolate GRADLE_USER_HOME per invocation so parallel scans/tests do not contend on ~/.gradle/caches/jars-9
-            // (e.g. "Failed to create Jar file ... jackson-core-*.jar", wrapped as ExecutionException).
-            // --no-daemon avoids leaving daemons bound to the temporary home.
-            List<String> args = Lists.newArrayList(
-                    "--no-daemon",
-                    "--gradle-user-home", gradleUserHome.toAbsolutePath().toString(),
-                    "generateDepTrees", "-q", "-I", initScript.toString(),
+            // Run "gradle generateDepTrees -q -I <path-to-init-script>" -Dcom.jfrog.depsTreeOutputFile=<path-to-output-file>
+            List<String> args = Lists.newArrayList("generateDepTrees", "-q", "-I", initScript.toString(),
                     "-Dcom.jfrog.depsTreeOutputFile=" + outputFile.toString());
             runCommand(workingDirectory, args, logger);
             List<File> files = new ArrayList<>();
@@ -100,11 +94,6 @@ public class GradleDriver {
         } finally {
             FileUtils.forceDelete(initScript.toFile());
             FileUtils.forceDelete(outputFile.toFile());
-            try {
-                FileUtils.deleteDirectory(gradleUserHome.toFile());
-            } catch (IOException cleanupEx) {
-                FileUtils.deleteQuietly(gradleUserHome.toFile());
-            }
         }
     }
 

--- a/src/main/java/com/jfrog/ide/common/gradle/GradleDriver.java
+++ b/src/main/java/com/jfrog/ide/common/gradle/GradleDriver.java
@@ -67,6 +67,7 @@ public class GradleDriver {
         Path initScript = Files.createTempFile("init-script", encodedPath);
         logger.debug("dependencies.gradle init script path: " + initScript);
         Path outputFile = Files.createTempFile("gradle-deps-tree", "");
+        Path gradleUserHome = Files.createTempDirectory("jfrog-gradle-user-home-");
         try (InputStream gradleInitScript = getClass().getResourceAsStream("/gradle-dep-tree.gradle")) {
             if (gradleInitScript == null) {
                 throw new IOException("Couldn't find dependencies.gradle init script.");
@@ -75,8 +76,13 @@ public class GradleDriver {
             // Copy init script to the temp file
             Files.copy(gradleInitScript, initScript, StandardCopyOption.REPLACE_EXISTING);
 
-            // Run "gradle generateDepTrees -q -I <path-to-init-script>" -Dcom.jfrog.depsTreeOutputFile=<path-to-output-file>
-            List<String> args = Lists.newArrayList("generateDepTrees", "-q", "-I", initScript.toString(),
+            // Isolate GRADLE_USER_HOME per invocation so parallel scans/tests do not contend on ~/.gradle/caches/jars-9
+            // (e.g. "Failed to create Jar file ... jackson-core-*.jar", wrapped as ExecutionException).
+            // --no-daemon avoids leaving daemons bound to the temporary home.
+            List<String> args = Lists.newArrayList(
+                    "--no-daemon",
+                    "--gradle-user-home", gradleUserHome.toAbsolutePath().toString(),
+                    "generateDepTrees", "-q", "-I", initScript.toString(),
                     "-Dcom.jfrog.depsTreeOutputFile=" + outputFile.toString());
             runCommand(workingDirectory, args, logger);
             List<File> files = new ArrayList<>();
@@ -94,6 +100,11 @@ public class GradleDriver {
         } finally {
             FileUtils.forceDelete(initScript.toFile());
             FileUtils.forceDelete(outputFile.toFile());
+            try {
+                FileUtils.deleteDirectory(gradleUserHome.toFile());
+            } catch (IOException cleanupEx) {
+                FileUtils.deleteQuietly(gradleUserHome.toFile());
+            }
         }
     }
 

--- a/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactPath.java
+++ b/src/main/java/com/jfrog/ide/common/nodes/subentities/ImpactPath.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.common.nodes.subentities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.util.Objects;
 
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ImpactPath {
     @JsonProperty()
     private String name;

--- a/src/test/resources/gradle/groovy/api/build.gradle
+++ b/src/test/resources/gradle/groovy/api/build.gradle
@@ -4,9 +4,8 @@ configurations {
 
 dependencies {
     implementation project(':shared')
-    implementation module("commons-lang:commons-lang:2.4") {
-        dependency("commons-io:commons-io:1.2")
-    }
+    implementation "commons-lang:commons-lang:2.4"
+    implementation "commons-io:commons-io:1.2"
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }

--- a/src/test/resources/gradle/groovy/build.gradle
+++ b/src/test/resources/gradle/groovy/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '5.+')
     }
     configurations.classpath {
         resolutionStrategy {

--- a/src/test/resources/gradle/kotlin/build.gradle.kts
+++ b/src/test/resources/gradle/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jfrog.buildinfo", "build-info-extractor-gradle", "4.+")
+        classpath("org.jfrog.buildinfo", "build-info-extractor-gradle", "5.+")
     }
     configurations.classpath {
         resolutionStrategy {

--- a/src/test/resources/gradle/kotlin/build.gradle.kts
+++ b/src/test/resources/gradle/kotlin/build.gradle.kts
@@ -103,8 +103,8 @@ configure<org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention> {
     publish {
         repository {
             setRepoKey("libs-snapshot-local") // The Artifactory repository key to publish to
-            setUsername(findProperty("artifactory_user")) // The publisher user name
-            setPassword(findProperty("artifactory_password")) // The publisher password
+            setUsername(findProperty("artifactory_user")?.toString().orEmpty()) // The publisher user name
+            setPassword(findProperty("artifactory_password")?.toString().orEmpty()) // The publisher password
             // This is an optional section for configuring Ivy publication (when publishIvy = true).
             ivy {
                 setIvyLayout("[organization]/[module]/ivy-[revision].xml")

--- a/src/test/resources/gradle/unresolvedGroovy/api/build.gradle
+++ b/src/test/resources/gradle/unresolvedGroovy/api/build.gradle
@@ -4,9 +4,8 @@ configurations {
 
 dependencies {
     implementation project(':shared')
-    implementation module("commons-lang:commons-lang:2.4") {
-        dependency("commons-io:commons-io:1.2")
-    }
+    implementation "commons-lang:commons-lang:2.4"
+    implementation "commons-io:commons-io:1.2"
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }

--- a/src/test/resources/gradle/unresolvedGroovy/build.gradle
+++ b/src/test/resources/gradle/unresolvedGroovy/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '5.+')
     }
     configurations.classpath {
         resolutionStrategy {

--- a/src/test/resources/gradle/unresolvedKotlin/build.gradle.kts
+++ b/src/test/resources/gradle/unresolvedKotlin/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jfrog.buildinfo", "build-info-extractor-gradle", "4.+")
+        classpath("org.jfrog.buildinfo", "build-info-extractor-gradle", "5.+")
     }
     configurations.classpath {
         resolutionStrategy {

--- a/src/test/resources/gradle/unresolvedKotlin/build.gradle.kts
+++ b/src/test/resources/gradle/unresolvedKotlin/build.gradle.kts
@@ -103,8 +103,8 @@ configure<org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention> {
     publish {
         repository {
             setRepoKey("libs-snapshot-local") // The Artifactory repository key to publish to
-            setUsername(findProperty("artifactory_user")) // The publisher user name
-            setPassword(findProperty("artifactory_password")) // The publisher password
+            setUsername(findProperty("artifactory_user")?.toString().orEmpty()) // The publisher user name
+            setPassword(findProperty("artifactory_password")?.toString().orEmpty()) // The publisher password
             // This is an optional section for configuring Ivy publication (when publishIvy = true).
             ivy {
                 setIvyLayout("[organization]/[module]/ivy-[revision].xml")

--- a/src/test/resources/packageFinder/gradle/api/build.gradle
+++ b/src/test/resources/packageFinder/gradle/api/build.gradle
@@ -6,9 +6,8 @@ configurations {
 
 dependencies {
     implementation project(':shared')
-    implementation module("commons-lang:commons-lang:2.4") {
-        dependency("commons-io:commons-io:1.2")
-    }
+    implementation "commons-lang:commons-lang:2.4"
+    implementation "commons-io:commons-io:1.2"
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }


### PR DESCRIPTION
## `chore(deps): bump Jackson, build-info, gradle-dep-tree; align Gradle test fixtures`

## Summary

This change updates core library versions (JFrog build-info extractors, Jackson, `gradle-dep-tree`), makes `ImpactPath` tolerant of unknown JSON fields for Jackson compatibility, and refreshes Gradle-based test resources (Artifactory Gradle plugin 5.x, simpler dependency declarations, Kotlin DSL property handling). `.gitignore` now ignores `bin`.

## Changes

- **`build.gradle`**: `buildInfoVersion` `2.41.13` → `2.43.6`; centralize Jackson at `2.17.3` for `jackson-dataformat-yaml` and `jackson-databind` (noted as security-related, Java 8+); `gradle-dep-tree` `3.0.1` → `3.2.1`.
- **`ImpactPath.java`**: add `@JsonIgnoreProperties(ignoreUnknown = true)`.
- **`.gitignore`**: add `bin`.
- **Gradle test fixtures** (`src/test/resources/gradle/**`, `packageFinder/gradle`): `build-info-extractor-gradle` classpath `4.+` → `5.+`; replace `module { dependency(...) }` style with plain `implementation "..."` strings for commons-lang/commons-io in api projects; in Kotlin DSL samples, coerce `findProperty(...)` to `String` with `?.toString().orEmpty()` for Artifactory username/password.

## Notes

- Jackson upgrade is intended to stay compatible with Java 8+ per the in-file comment; consumers should confirm no conflicting Jackson constraints on the classpath.